### PR TITLE
Implemented App shell layout UI

### DIFF
--- a/frontend/src/app/(protected)/dashboard/page.tsx
+++ b/frontend/src/app/(protected)/dashboard/page.tsx
@@ -1,92 +1,172 @@
 "use client";
 
-import { Button, Card, Col, Row, Spin, Typography } from "antd";
-import { useAuthActions, useAuthState } from "@/providers/authProvider";
+import { Button, Card, Col, Row, Table, Tag, Typography } from "antd";
+import type { ColumnsType } from "antd/es/table";
+import { WorkspacePageHeader } from "@/components/workspaceShell/WorkspacePageHeader";
 import { useStyles } from "./style";
 
 const { Paragraph, Text, Title } = Typography;
 
+interface DashboardMetric {
+  label: string;
+  value: string;
+}
+
+interface RecentDatasetRow {
+  key: string;
+  dataset: string;
+  updated: string;
+  status: string;
+  statusColor: string;
+  health: string;
+  healthTone: "good" | "warning" | "error";
+  lastAnalysis: string;
+}
+
+const DASHBOARD_METRICS: DashboardMetric[] = [
+  {
+    label: "Total Datasets",
+    value: "18",
+  },
+  {
+    label: "Processed Versions",
+    value: "42",
+  },
+  {
+    label: "ML Experiments",
+    value: "11",
+  },
+  {
+    label: "Reports Generated",
+    value: "9",
+  },
+];
+
+const RECENT_DATASETS: RecentDatasetRow[] = [
+  {
+    key: "customer-churn",
+    dataset: "Customer Churn Dataset",
+    updated: "2 hours ago",
+    status: "Profiled",
+    statusColor: "blue",
+    health: "86 / 100",
+    healthTone: "good",
+    lastAnalysis: "Regression Ready",
+  },
+  {
+    key: "retail-sales",
+    dataset: "Retail Sales Q4",
+    updated: "Yesterday",
+    status: "Transformed",
+    statusColor: "purple",
+    health: "72 / 100",
+    healthTone: "warning",
+    lastAnalysis: "Clustering Run",
+  },
+  {
+    key: "fraud-signals",
+    dataset: "Fraud Signals v2",
+    updated: "3 days ago",
+    status: "Issues",
+    statusColor: "red",
+    health: "54 / 100",
+    healthTone: "error",
+    lastAnalysis: "Anomalies Found",
+  },
+];
+
 export default function DashboardPage() {
-  const { logout } = useAuthActions();
-  const { isAuthenticated, isInitialized, profile, session } = useAuthState();
-  const { styles } = useStyles();
+  const { styles, cx } = useStyles();
 
-  if (!isInitialized) {
-    return (
-      <main className={styles.loadingState}>
-        <Spin size="large" />
-      </main>
-    );
-  }
-
-  if (!isAuthenticated) {
-    return null;
-  }
+  const columns: ColumnsType<RecentDatasetRow> = [
+    {
+      title: "Dataset",
+      dataIndex: "dataset",
+      key: "dataset",
+    },
+    {
+      title: "Updated",
+      dataIndex: "updated",
+      key: "updated",
+    },
+    {
+      title: "Status",
+      dataIndex: "status",
+      key: "status",
+      render: (_, record) => <Tag color={record.statusColor}>{record.status}</Tag>,
+    },
+    {
+      title: "Health",
+      dataIndex: "health",
+      key: "health",
+      render: (_, record) => (
+        <span
+          className={cx(
+            record.healthTone === "good" && styles.healthGood,
+            record.healthTone === "warning" && styles.healthWarning,
+            record.healthTone === "error" && styles.healthError,
+          )}
+        >
+          {record.health}
+        </span>
+      ),
+    },
+    {
+      title: "Last Analysis",
+      dataIndex: "lastAnalysis",
+      key: "lastAnalysis",
+    },
+  ];
 
   return (
-    <main className={styles.page}>
-      <section className={styles.shell}>
-        <div className={styles.header}>
-          <div>
-            <Text className={styles.kicker}>AstraLab Workspace</Text>
-            <Title level={1} className={styles.title}>
-              Welcome back, {profile?.user?.name || profile?.user?.userName || "User"}
-            </Title>
-            <Paragraph className={styles.description}>
-              Your session is active and authenticated requests now flow through the
-              shared auth provider and axios instance.
-            </Paragraph>
-          </div>
+    <>
+      <WorkspacePageHeader
+        title="Dataset Dashboard"
+        description="Upload, profile, analyze, and model your datasets from one workspace."
+      />
 
-          <Button
-            size="large"
-            onClick={() => logout()}
-            className={styles.logoutButton}
-          >
-            Sign Out
-          </Button>
+      <Card className={styles.uploadCard}>
+        <div>
+          <Title level={3} className={styles.uploadTitle}>
+            Upload a New Dataset
+          </Title>
+          <Paragraph className={styles.uploadDescription}>
+            Start a new profiling and analysis workflow by uploading a CSV or JSON
+            file.
+          </Paragraph>
         </div>
 
-        <Row gutter={[20, 20]}>
-          <Col xs={24} md={8}>
-            <Card bordered className={styles.infoCard}>
-              <Text className={styles.cardLabel}>Authenticated User</Text>
-              <Title level={3} className={styles.cardValue}>
-                {profile?.user?.emailAddress || "Unavailable"}
+        <Button type="primary" size="large">
+          Upload Dataset
+        </Button>
+      </Card>
+
+      <Row gutter={[20, 20]}>
+        {DASHBOARD_METRICS.map((metric) => (
+          <Col key={metric.label} xs={24} sm={12} xl={6}>
+            <Card className={styles.metricCard}>
+              <Text className={styles.metricLabel}>{metric.label}</Text>
+              <Title level={3} className={styles.metricValue}>
+                {metric.value}
               </Title>
             </Card>
           </Col>
+        ))}
+      </Row>
 
-          <Col xs={24} md={8}>
-            <Card bordered className={styles.infoCard}>
-              <Text className={styles.cardLabel}>Tenant</Text>
-              <Title level={3} className={styles.cardValue}>
-                {profile?.tenant?.tenancyName || session?.tenancyName || "Default"}
-              </Title>
-            </Card>
-          </Col>
+      <Card className={styles.tableCard}>
+        <Title level={3} className={styles.tableTitle}>
+          Recent Datasets
+        </Title>
 
-          <Col xs={24} md={8}>
-            <Card bordered className={styles.infoCard}>
-              <Text className={styles.cardLabel}>User ID</Text>
-              <Title level={3} className={styles.cardValue}>
-                {session?.userId || "Unknown"}
-              </Title>
-            </Card>
-          </Col>
-        </Row>
-
-        <Card bordered className={styles.summaryCard}>
-          <Title level={4} className={styles.summaryTitle}>
-            Auth wiring completed
-          </Title>
-          <Paragraph className={styles.summaryText}>
-            JWT session storage, request header injection, auth bootstrap, and 401
-            handling are now centralized. This route is the first protected landing
-            page for the frontend.
-          </Paragraph>
-        </Card>
-      </section>
-    </main>
+        <Table<RecentDatasetRow>
+          columns={columns}
+          dataSource={RECENT_DATASETS}
+          pagination={false}
+          className={styles.table}
+          scroll={{ x: 900 }}
+        />
+      </Card>
+    </>
   );
 }

--- a/frontend/src/app/(protected)/dashboard/style.ts
+++ b/frontend/src/app/(protected)/dashboard/style.ts
@@ -3,117 +3,129 @@
 import { createStyles } from "antd-style";
 
 export const useStyles = createStyles(({ token, css }) => ({
-  page: css`
-    min-height: 100vh;
-    padding: 28px;
-    background:
-      radial-gradient(circle at top left, rgba(47, 140, 255, 0.16), transparent 24%),
-      linear-gradient(180deg, #09111f 0%, #070d19 100%);
-  `,
-
-  shell: css`
-    width: 100%;
-    max-width: 1240px;
-    margin: 0 auto;
-    padding: 36px;
-    border: 1px solid rgba(42, 58, 93, 0.72);
-    border-radius: 32px;
-    background: linear-gradient(180deg, rgba(13, 21, 38, 0.98), rgba(10, 16, 30, 0.98));
-    box-shadow: 0 32px 96px rgba(0, 0, 0, 0.34);
-  `,
-
-  loadingState: css`
-    min-height: 100vh;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    background: linear-gradient(180deg, #09111f 0%, #070d19 100%);
-  `,
-
-  header: css`
-    display: flex;
-    align-items: flex-start;
-    justify-content: space-between;
-    gap: 24px;
-    margin-bottom: 28px;
-
-    @media (max-width: 768px) {
-      flex-direction: column;
-    }
-  `,
-
-  kicker: css`
-    color: ${token.colorPrimary};
-    font-size: 14px;
-    font-weight: 700;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-  `,
-
-  title: css`
-    margin: 10px 0 8px !important;
-    color: ${token.colorText} !important;
-    font-size: clamp(34px, 4vw, 48px) !important;
-    letter-spacing: -0.04em !important;
-  `,
-
-  description: css`
-    max-width: 720px;
-    margin: 0 !important;
-    color: ${token.colorTextSecondary} !important;
-    font-size: 18px;
-  `,
-
-  logoutButton: css`
-    &.ant-btn {
-      min-width: 140px;
-    }
-  `,
-
-  infoCard: css`
+  uploadCard: css`
     &.ant-card {
-      height: 100%;
-      border-radius: 22px;
+      margin-bottom: 22px;
       border-color: rgba(40, 58, 92, 0.92);
-      background: rgba(16, 25, 43, 0.9);
+      border-radius: 24px;
+      background: rgba(17, 26, 45, 0.94);
       box-shadow: none;
     }
 
     .ant-card-body {
-      padding: 24px 22px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 20px;
+      padding: 28px 26px;
+
+      @media (max-width: 768px) {
+        flex-direction: column;
+        align-items: flex-start;
+      }
     }
   `,
 
-  cardLabel: css`
+  uploadTitle: css`
+    margin: 0 0 6px !important;
+    color: ${token.colorText} !important;
+  `,
+
+  uploadDescription: css`
+    margin: 0 !important;
+    color: ${token.colorTextSecondary} !important;
+    font-size: 16px;
+  `,
+
+  metricCard: css`
+    &.ant-card {
+      height: 100%;
+      border-color: rgba(40, 58, 92, 0.92);
+      border-radius: 22px;
+      background: rgba(17, 26, 45, 0.94);
+      box-shadow: none;
+    }
+
+    .ant-card-body {
+      padding: 20px 22px;
+    }
+  `,
+
+  metricLabel: css`
     color: ${token.colorTextSecondary};
     font-size: 14px;
   `,
 
-  cardValue: css`
-    margin: 12px 0 0 !important;
+  metricValue: css`
+    margin: 10px 0 0 !important;
     color: ${token.colorText} !important;
-    font-size: 26px !important;
-    line-height: 1.2 !important;
+    font-size: 34px !important;
+    line-height: 1.1 !important;
   `,
 
-  summaryCard: css`
+  tableCard: css`
     &.ant-card {
       margin-top: 24px;
-      border-radius: 24px;
       border-color: rgba(40, 58, 92, 0.92);
-      background: rgba(16, 25, 43, 0.88);
+      border-radius: 24px;
+      background: rgba(17, 26, 45, 0.94);
       box-shadow: none;
+    }
+
+    .ant-card-body {
+      padding: 22px 22px 16px;
     }
   `,
 
-  summaryTitle: css`
+  tableTitle: css`
+    margin-bottom: 18px !important;
     color: ${token.colorText} !important;
-    margin-bottom: 8px !important;
   `,
 
-  summaryText: css`
-    margin: 0 !important;
-    color: ${token.colorTextSecondary} !important;
-    font-size: 16px;
+  table: css`
+    .ant-table {
+      background: transparent;
+    }
+
+    .ant-table-container {
+      border-radius: 18px;
+      overflow: hidden;
+      border: 1px solid rgba(31, 45, 72, 0.9);
+    }
+
+    .ant-table-thead > tr > th {
+      background: rgba(11, 19, 35, 0.95);
+      color: ${token.colorTextSecondary};
+      border-bottom-color: rgba(31, 45, 72, 0.9);
+      font-size: 12px;
+      font-weight: 700;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+    }
+
+    .ant-table-tbody > tr > td {
+      background: rgba(13, 22, 39, 0.96);
+      color: ${token.colorText};
+      border-bottom-color: rgba(23, 34, 55, 0.9);
+    }
+
+    .ant-table-tbody > tr:last-child > td {
+      border-bottom: none;
+    }
+  `,
+
+  healthGood: css`
+    color: ${token.colorSuccess};
+    font-weight: 700;
+  `,
+
+  healthWarning: css`
+    color: ${token.colorWarning};
+    font-weight: 700;
+  `,
+
+  healthError: css`
+    color: ${token.colorError};
+    font-weight: 700;
   `,
 }));

--- a/frontend/src/app/(protected)/layout.tsx
+++ b/frontend/src/app/(protected)/layout.tsx
@@ -1,0 +1,6 @@
+import type { PropsWithChildren } from "react";
+import { WorkspaceShell } from "@/components/workspaceShell/WorkspaceShell";
+
+export default function ProtectedLayout({ children }: PropsWithChildren) {
+  return <WorkspaceShell>{children}</WorkspaceShell>;
+}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { AuthBootstrap } from "@/components/AuthBootstrap";
 import { AppThemeProvider } from "@/components/AppThemeProvider";
 import { AuthProvider } from "@/providers/authProvider";
 import "./globals.css";
@@ -17,7 +18,10 @@ export default function RootLayout({
     <html lang="en">
       <body>
         <AppThemeProvider>
-          <AuthProvider>{children}</AuthProvider>
+          <AuthProvider>
+            <AuthBootstrap />
+            {children}
+          </AuthProvider>
         </AppThemeProvider>
       </body>
     </html>

--- a/frontend/src/components/AuthBootstrap.tsx
+++ b/frontend/src/components/AuthBootstrap.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useEffect, useEffectEvent, useRef } from "react";
+import { LOGIN_ROUTE } from "@/constants/auth";
+import { useAuthActions } from "@/providers/authProvider";
+import { setUnauthorizedHandler } from "@/utils/axiosInstance";
+
+export function AuthBootstrap() {
+  const { initializeAuth, logout } = useAuthActions();
+  const hasInitialized = useRef(false);
+
+  const handleUnauthorized = useEffectEvent(() => {
+    logout({ redirectTo: LOGIN_ROUTE });
+  });
+
+  useEffect(() => {
+    if (hasInitialized.current) {
+      return;
+    }
+
+    hasInitialized.current = true;
+    void initializeAuth();
+  }, [initializeAuth]);
+
+  useEffect(() => {
+    setUnauthorizedHandler(() => {
+      handleUnauthorized();
+    });
+
+    return () => {
+      setUnauthorizedHandler(null);
+    };
+  }, []);
+
+  return null;
+}

--- a/frontend/src/components/workspaceShell/WorkspacePageHeader.tsx
+++ b/frontend/src/components/workspaceShell/WorkspacePageHeader.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { Typography } from "antd";
+import type { WorkspacePageHeaderProps } from "@/types/workspace";
+import { useStyles } from "./style";
+
+const { Paragraph, Title } = Typography;
+
+export function WorkspacePageHeader({
+  title,
+  description,
+  actions,
+}: WorkspacePageHeaderProps) {
+  const { styles } = useStyles();
+
+  return (
+    <div className={styles.pageHeader}>
+      <div>
+        <Title level={1} className={styles.pageHeaderTitle}>
+          {title}
+        </Title>
+        <Paragraph className={styles.pageHeaderDescription}>
+          {description}
+        </Paragraph>
+      </div>
+
+      {actions ?? null}
+    </div>
+  );
+}

--- a/frontend/src/components/workspaceShell/WorkspaceShell.tsx
+++ b/frontend/src/components/workspaceShell/WorkspaceShell.tsx
@@ -1,0 +1,228 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { useState } from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import {
+  Avatar,
+  Button,
+  Drawer,
+  Dropdown,
+  Input,
+  Spin,
+  Typography,
+} from "antd";
+import type { MenuProps } from "antd";
+import {
+  BarChartOutlined,
+  BellOutlined,
+  DashboardOutlined,
+  DatabaseOutlined,
+  ExperimentOutlined,
+  FileTextOutlined,
+  LogoutOutlined,
+  MenuOutlined,
+  RobotOutlined,
+  SearchOutlined,
+  SettingOutlined,
+} from "@ant-design/icons";
+import { WORKSPACE_NAVIGATION } from "@/constants/workspace";
+import { useAuthActions, useAuthState } from "@/providers/authProvider";
+import type {
+  WorkspaceIconKey,
+  WorkspaceNavItem,
+  WorkspaceShellProps,
+} from "@/types/workspace";
+import { useStyles } from "./style";
+
+const { Text, Title } = Typography;
+
+const ICON_MAP: Record<WorkspaceIconKey, ReactNode> = {
+  dashboard: <DashboardOutlined />,
+  datasets: <DatabaseOutlined />,
+  analysis: <BarChartOutlined />,
+  assistant: <RobotOutlined />,
+  mlWorkspace: <ExperimentOutlined />,
+  reports: <FileTextOutlined />,
+  settings: <SettingOutlined />,
+};
+
+function getUserInitials(name: string) {
+  const segments = name
+    .split(" ")
+    .map((value) => value.trim())
+    .filter(Boolean)
+    .slice(0, 2);
+
+  if (segments.length === 0) {
+    return "AL";
+  }
+
+  return segments.map((value) => value[0]?.toUpperCase() ?? "").join("");
+}
+
+function isItemSelected(pathname: string, item: WorkspaceNavItem) {
+  return pathname === item.href || pathname.startsWith(`${item.href}/`);
+}
+
+export function WorkspaceShell({ children }: WorkspaceShellProps) {
+  const { styles, cx } = useStyles();
+  const pathname = usePathname();
+  const { logout } = useAuthActions();
+  const { isAuthenticated, isInitialized, profile } = useAuthState();
+  const [isMobileNavigationOpen, setIsMobileNavigationOpen] = useState(false);
+
+  const displayName =
+    profile?.user?.name || profile?.user?.userName || "AstraLab User";
+  const emailAddress = profile?.user?.emailAddress || "Authenticated session";
+  const initials = getUserInitials(displayName);
+
+  const profileMenuItems: MenuProps["items"] = [
+    {
+      key: "profile",
+      disabled: true,
+      label: (
+        <div className={styles.dropdownMeta}>
+          <span className={styles.dropdownTitle}>{displayName}</span>
+          <span className={styles.dropdownText}>{emailAddress}</span>
+        </div>
+      ),
+    },
+    {
+      type: "divider",
+    },
+    {
+      key: "logout",
+      icon: <LogoutOutlined />,
+      label: "Sign out",
+    },
+  ];
+
+  const navigationContent = (
+    <div className={styles.mobileDrawerContent}>
+      <Title level={4} className={styles.brand}>
+        AstraLab
+      </Title>
+
+      <section className={styles.navigationSection}>
+        <Text className={styles.sectionLabel}>Workspace</Text>
+
+        <nav className={styles.navigationList} aria-label="Workspace navigation">
+          {WORKSPACE_NAVIGATION.map((item) => {
+            const isSelected = isItemSelected(pathname, item);
+            const className = cx(
+              styles.navItem,
+              isSelected && styles.navItemActive,
+              !item.isAvailable && styles.navItemDisabled,
+            );
+
+            if (!item.isAvailable) {
+              return (
+                <div key={item.key} className={className} aria-disabled="true">
+                  <span className={styles.navIcon}>{ICON_MAP[item.icon]}</span>
+                  <span>{item.label}</span>
+                </div>
+              );
+            }
+
+            return (
+              <Link
+                key={item.key}
+                href={item.href}
+                className={className}
+                aria-current={isSelected ? "page" : undefined}
+                onClick={() => setIsMobileNavigationOpen(false)}
+              >
+                <span className={styles.navIcon}>{ICON_MAP[item.icon]}</span>
+                <span>{item.label}</span>
+              </Link>
+            );
+          })}
+        </nav>
+      </section>
+    </div>
+  );
+
+  if (!isInitialized) {
+    return (
+      <main className={styles.loadingState}>
+        <Spin size="large" />
+      </main>
+    );
+  }
+
+  if (!isAuthenticated) {
+    return null;
+  }
+
+  return (
+    <main className={styles.page}>
+      <div className={styles.frame}>
+        <aside className={styles.sidebar}>{navigationContent}</aside>
+
+        <section className={styles.contentColumn}>
+          <header className={styles.header}>
+            <Button
+              type="default"
+              icon={<MenuOutlined />}
+              className={styles.mobileMenuButton}
+              onClick={() => setIsMobileNavigationOpen(true)}
+              aria-label="Open navigation"
+            />
+
+            <Title level={4} className={styles.mobileBrand}>
+              AstraLab
+            </Title>
+
+            <Input
+              size="large"
+              placeholder="Search datasets, reports, experiments..."
+              prefix={<SearchOutlined />}
+              className={styles.search}
+              aria-label="Search workspace"
+            />
+
+            <div className={styles.headerUtilities}>
+              <Button type="default" className={styles.utilityButton}>
+                <BellOutlined /> Alerts
+              </Button>
+
+              <Dropdown
+                menu={{
+                  items: profileMenuItems,
+                  onClick: ({ key }) => {
+                    if (key === "logout") {
+                      logout();
+                    }
+                  },
+                }}
+                trigger={["click"]}
+              >
+                <Button className={styles.profileButton} aria-label="Open profile menu">
+                  <Avatar size={36} className={styles.avatar}>
+                    {initials}
+                  </Avatar>
+                </Button>
+              </Dropdown>
+            </div>
+          </header>
+
+          <div className={styles.contentViewport}>
+            <div className={styles.contentInner}>{children}</div>
+          </div>
+        </section>
+      </div>
+
+      <Drawer
+        placement="left"
+        width={280}
+        open={isMobileNavigationOpen}
+        onClose={() => setIsMobileNavigationOpen(false)}
+        title="Workspace"
+      >
+        {navigationContent}
+      </Drawer>
+    </main>
+  );
+}

--- a/frontend/src/components/workspaceShell/style.ts
+++ b/frontend/src/components/workspaceShell/style.ts
@@ -1,0 +1,281 @@
+"use client";
+
+import { createStyles } from "antd-style";
+
+export const useStyles = createStyles(({ token, css }) => ({
+  loadingState: css`
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background:
+      radial-gradient(circle at top left, rgba(47, 140, 255, 0.16), transparent 24%),
+      linear-gradient(180deg, #09111f 0%, #070d19 100%);
+  `,
+
+  page: css`
+    min-height: 100vh;
+    padding: 14px;
+    background:
+      radial-gradient(circle at top left, rgba(47, 140, 255, 0.12), transparent 22%),
+      radial-gradient(circle at bottom right, rgba(255, 122, 26, 0.08), transparent 20%),
+      linear-gradient(180deg, #09111f 0%, #070d19 100%);
+  `,
+
+  frame: css`
+    min-height: calc(100vh - 28px);
+    display: grid;
+    grid-template-columns: 240px minmax(0, 1fr);
+    overflow: hidden;
+    border: 1px solid rgba(33, 49, 77, 0.95);
+    border-radius: 28px;
+    background: rgba(8, 15, 28, 0.96);
+    box-shadow: 0 32px 96px rgba(0, 0, 0, 0.34);
+
+    @media (max-width: 1024px) {
+      grid-template-columns: minmax(0, 1fr);
+    }
+  `,
+
+  sidebar: css`
+    display: flex;
+    flex-direction: column;
+    padding: 28px 16px 24px;
+    border-right: 1px solid rgba(33, 49, 77, 0.92);
+    background: rgba(17, 26, 45, 0.92);
+
+    @media (max-width: 1024px) {
+      display: none;
+    }
+  `,
+
+  brand: css`
+    margin: 0;
+    color: ${token.colorText} !important;
+    font-size: 18px !important;
+    font-weight: 700 !important;
+    letter-spacing: -0.03em;
+  `,
+
+  mobileBrand: css`
+    display: none;
+    margin: 0 !important;
+    color: ${token.colorText} !important;
+
+    @media (max-width: 1024px) {
+      display: block;
+    }
+  `,
+
+  navigationSection: css`
+    margin-top: 48px;
+  `,
+
+  sectionLabel: css`
+    display: block;
+    margin-bottom: 14px;
+    padding: 0 10px;
+    color: ${token.colorTextSecondary};
+    font-size: 12px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  `,
+
+  navigationList: css`
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  `,
+
+  navItem: css`
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    min-height: 44px;
+    padding: 0 14px;
+    border: 1px solid transparent;
+    border-radius: 14px;
+    color: ${token.colorTextSecondary};
+    font-size: 15px;
+    font-weight: 500;
+    text-decoration: none;
+    transition:
+      background 0.2s ease,
+      border-color 0.2s ease,
+      color 0.2s ease;
+
+    &:hover {
+      color: ${token.colorText};
+      border-color: rgba(42, 58, 93, 0.7);
+      background: rgba(21, 33, 57, 0.8);
+    }
+  `,
+
+  navItemActive: css`
+    color: ${token.colorText};
+    border-color: rgba(42, 58, 93, 0.92);
+    background: rgba(34, 49, 79, 0.95);
+  `,
+
+  navItemDisabled: css`
+    cursor: not-allowed;
+    opacity: 0.58;
+
+    &:hover {
+      color: ${token.colorTextSecondary};
+      border-color: transparent;
+      background: transparent;
+    }
+  `,
+
+  navIcon: css`
+    font-size: 17px;
+  `,
+
+  contentColumn: css`
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+  `,
+
+  header: css`
+    display: flex;
+    align-items: center;
+    gap: 18px;
+    padding: 14px 22px;
+    border-bottom: 1px solid rgba(33, 49, 77, 0.9);
+    background: rgba(17, 25, 44, 0.88);
+
+    @media (max-width: 768px) {
+      flex-wrap: wrap;
+      padding: 14px 16px;
+    }
+  `,
+
+  mobileMenuButton: css`
+    display: none;
+
+    @media (max-width: 1024px) {
+      &.ant-btn {
+        display: inline-flex;
+      }
+    }
+  `,
+
+  search: css`
+    flex: 1;
+    min-width: 260px;
+    max-width: 520px;
+
+    &.ant-input-affix-wrapper {
+      border-radius: 999px;
+      background: rgba(26, 37, 64, 0.92);
+    }
+
+    @media (max-width: 768px) {
+      order: 3;
+      width: 100%;
+      max-width: 100%;
+      min-width: 100%;
+    }
+  `,
+
+  headerUtilities: css`
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-left: auto;
+  `,
+
+  utilityButton: css`
+    &.ant-btn {
+      min-width: 118px;
+      border-radius: 999px;
+    }
+  `,
+
+  profileButton: css`
+    &.ant-btn {
+      height: auto;
+      padding: 4px;
+      border: none;
+      background: transparent;
+      box-shadow: none;
+    }
+  `,
+
+  avatar: css`
+    background: ${token.colorPrimary};
+    color: #fff;
+    font-weight: 700;
+  `,
+
+  dropdownMeta: css`
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  `,
+
+  dropdownTitle: css`
+    color: ${token.colorText};
+    font-weight: 600;
+  `,
+
+  dropdownText: css`
+    color: ${token.colorTextSecondary};
+    font-size: 12px;
+  `,
+
+  contentViewport: css`
+    flex: 1;
+    min-width: 0;
+    overflow: auto;
+  `,
+
+  contentInner: css`
+    width: 100%;
+    max-width: 1240px;
+    margin: 0 auto;
+    padding: 24px 24px 40px;
+
+    @media (max-width: 768px) {
+      padding: 20px 16px 28px;
+    }
+  `,
+
+  mobileDrawerContent: css`
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    padding: 12px 0;
+    background: transparent;
+  `,
+
+  pageHeader: css`
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 20px;
+    margin-bottom: 26px;
+
+    @media (max-width: 768px) {
+      flex-direction: column;
+      margin-bottom: 22px;
+    }
+  `,
+
+  pageHeaderTitle: css`
+    margin: 0 0 6px !important;
+    color: ${token.colorText} !important;
+    font-size: clamp(34px, 3vw, 44px) !important;
+    letter-spacing: -0.04em !important;
+  `,
+
+  pageHeaderDescription: css`
+    max-width: 760px;
+    margin: 0 !important;
+    color: ${token.colorTextSecondary} !important;
+    font-size: 17px;
+  `,
+}));

--- a/frontend/src/constants/workspace.ts
+++ b/frontend/src/constants/workspace.ts
@@ -1,0 +1,54 @@
+import type { WorkspaceNavItem } from "@/types/workspace";
+import { DASHBOARD_ROUTE } from "./auth";
+
+export const WORKSPACE_NAVIGATION: WorkspaceNavItem[] = [
+  {
+    key: "dashboard",
+    label: "Dashboard",
+    href: DASHBOARD_ROUTE,
+    icon: "dashboard",
+    isAvailable: true,
+  },
+  {
+    key: "datasets",
+    label: "Datasets",
+    href: "/datasets",
+    icon: "datasets",
+    isAvailable: false,
+  },
+  {
+    key: "analysis",
+    label: "Analysis",
+    href: "/analysis",
+    icon: "analysis",
+    isAvailable: false,
+  },
+  {
+    key: "assistant",
+    label: "AI Assistant",
+    href: "/ai-assistant",
+    icon: "assistant",
+    isAvailable: false,
+  },
+  {
+    key: "ml-workspace",
+    label: "ML Workspace",
+    href: "/ml-workspace",
+    icon: "mlWorkspace",
+    isAvailable: false,
+  },
+  {
+    key: "reports",
+    label: "Reports",
+    href: "/reports",
+    icon: "reports",
+    isAvailable: false,
+  },
+  {
+    key: "settings",
+    label: "Settings",
+    href: "/settings",
+    icon: "settings",
+    isAvailable: false,
+  },
+];

--- a/frontend/src/providers/authProvider/index.tsx
+++ b/frontend/src/providers/authProvider/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import axios from "axios";
-import { useContext, useEffect, useReducer, useRef } from "react";
+import { useContext, useReducer } from "react";
 import { useRouter } from "next/navigation";
 import type { PropsWithChildren } from "react";
 import {
@@ -24,7 +24,6 @@ import {
   getAuthSession,
   setAuthSession,
 } from "@/utils/authCookies";
-import { setUnauthorizedHandler } from "@/utils/axiosInstance";
 import {
   authenticate,
   getCurrentLoginInformations,
@@ -117,7 +116,6 @@ function getTenantAvailabilityMessage(
 export function AuthProvider({ children }: PropsWithChildren) {
   const [state, dispatch] = useReducer(AuthReducer, INITIAL_STATE);
   const router = useRouter();
-  const hasInitialized = useRef(false);
 
   const logout = (options?: { redirectTo?: string }) => {
     clearAuthSession();
@@ -242,27 +240,6 @@ export function AuthProvider({ children }: PropsWithChildren) {
       throw error;
     }
   };
-
-  useEffect(() => {
-    setUnauthorizedHandler(() => {
-      clearAuthSession();
-      dispatch(logoutSuccess());
-      router.replace(LOGIN_ROUTE);
-    });
-
-    return () => {
-      setUnauthorizedHandler(null);
-    };
-  }, [router]);
-
-  useEffect(() => {
-    if (hasInitialized.current) {
-      return;
-    }
-
-    hasInitialized.current = true;
-    void initializeAuth();
-  }, []);
 
   return (
     <AuthStateContext.Provider value={state}>

--- a/frontend/src/proxy.ts
+++ b/frontend/src/proxy.ts
@@ -6,12 +6,21 @@ import {
   LOGIN_ROUTE,
   REGISTER_ROUTE,
 } from "./constants/auth";
+import { WORKSPACE_NAVIGATION } from "./constants/workspace";
 import { parseAuthSession } from "./utils/authCookies";
+
+const PROTECTED_ROUTE_PREFIXES = WORKSPACE_NAVIGATION.map(({ href }) => href);
 
 function clearInvalidAuthCookie(response: NextResponse) {
   response.cookies.delete(AUTH_SESSION_COOKIE_NAME);
 
   return response;
+}
+
+function isProtectedRoute(pathname: string) {
+  return PROTECTED_ROUTE_PREFIXES.some(
+    (route) => pathname === route || pathname.startsWith(`${route}/`),
+  );
 }
 
 export function proxy(request: NextRequest) {
@@ -29,7 +38,7 @@ export function proxy(request: NextRequest) {
     return NextResponse.redirect(new URL(DASHBOARD_ROUTE, request.url));
   }
 
-  if (pathname.startsWith(DASHBOARD_ROUTE) && !hasValidSession) {
+  if (isProtectedRoute(pathname) && !hasValidSession) {
     const response = NextResponse.redirect(new URL(LOGIN_ROUTE, request.url));
 
     return hasSessionCookie ? clearInvalidAuthCookie(response) : response;
@@ -47,5 +56,15 @@ export function proxy(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ["/login", "/register", "/dashboard/:path*"],
+  matcher: [
+    "/login",
+    "/register",
+    "/dashboard/:path*",
+    "/datasets/:path*",
+    "/analysis/:path*",
+    "/ai-assistant/:path*",
+    "/ml-workspace/:path*",
+    "/reports/:path*",
+    "/settings/:path*",
+  ],
 };

--- a/frontend/src/types/workspace.ts
+++ b/frontend/src/types/workspace.ts
@@ -1,0 +1,28 @@
+import type { ReactNode } from "react";
+
+export type WorkspaceIconKey =
+  | "dashboard"
+  | "datasets"
+  | "analysis"
+  | "assistant"
+  | "mlWorkspace"
+  | "reports"
+  | "settings";
+
+export interface WorkspaceNavItem {
+  key: string;
+  label: string;
+  href: string;
+  icon: WorkspaceIconKey;
+  isAvailable: boolean;
+}
+
+export interface WorkspaceShellProps {
+  children: ReactNode;
+}
+
+export interface WorkspacePageHeaderProps {
+  title: string;
+  description: string;
+  actions?: ReactNode;
+}


### PR DESCRIPTION
## Summary
This PR introduces a reusable protected app shell for the frontend workspace experience.

Instead of hardwiring the layout into the dashboard page, the shell now lives at the protected route-group level and can be reused across all authenticated pages. The dashboard has been refactored to render only page-specific content inside that shared shell.

## What Changed
- Added a shared protected layout for authenticated routes
- Introduced a reusable `WorkspaceShell` component for:
  - sidebar navigation
  - top header
  - mobile navigation drawer
  - auth-aware profile/logout area
  - shared content container
- Added a reusable `WorkspacePageHeader` component for page title/description sections
- Moved workspace navigation into a typed config so the shell is route-driven
- Refactored the dashboard page to remove shell ownership and render content only
- Updated protected route handling so planned workspace routes are covered consistently

## UI Behavior
- Sidebar shows the planned workspace information architecture:
  - Dashboard
  - Datasets
  - Analysis
  - AI Assistant
  - ML Workspace
  - Reports
  - Settings
- Unimplemented sections are visible but disabled/non-interactive
- Header includes:
  - AstraLab branding
  - search UI
  - alerts button
  - profile/avatar trigger
- Logout remains functional
- Search and alerts are visual-only in this pass
- Mobile layouts collapse the sidebar into a drawer

## Why
This creates a single reusable shell for the protected area so future pages do not need to recreate layout chrome individually. It also keeps page content separate from app-level structure, which should make the frontend easier to scale and maintain.

## Validation
- `npm run lint`
- `tsc --noEmit`

`next build` compiled successfully but could not complete the final build step in the sandbox because of a `spawn EPERM` environment issue.
