### PR TITLE
Add ML result insights and experiment-aware dataset AI assistant

### DIFF
--- a/aspnet-core/src/AstraLab.Application/Services/AI/AiAutomaticInsightMetadata.cs
+++ b/aspnet-core/src/AstraLab.Application/Services/AI/AiAutomaticInsightMetadata.cs
@@ -13,6 +13,11 @@ namespace AstraLab.Services.AI
         /// </summary>
         public const string ProfilingCompletedGenerationTrigger = "profilingCompleted";
 
+        /// <summary>
+        /// The metadata trigger value used for experiment-completed automatic insights.
+        /// </summary>
+        public const string ExperimentCompletedGenerationTrigger = "experimentCompleted";
+
         private static readonly JsonSerializerOptions SerializerOptions = new JsonSerializerOptions
         {
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
@@ -44,6 +49,33 @@ namespace AstraLab.Services.AI
             }
 
             return metadata.GenerationTrigger == ProfilingCompletedGenerationTrigger;
+        }
+
+        /// <summary>
+        /// Determines whether the persisted metadata belongs to an automatic experiment-completed insight.
+        /// </summary>
+        public static bool IsAutomaticExperimentInsight(string metadataJson, long mlExperimentId)
+        {
+            if (!TryRead(metadataJson, out var metadata))
+            {
+                return false;
+            }
+
+            return metadata.GenerationTrigger == ExperimentCompletedGenerationTrigger &&
+                   metadata.MLExperimentId == mlExperimentId;
+        }
+
+        /// <summary>
+        /// Determines whether the persisted metadata belongs to any experiment-completed automatic insight.
+        /// </summary>
+        public static bool IsAutomaticExperimentInsight(string metadataJson)
+        {
+            if (!TryRead(metadataJson, out var metadata))
+            {
+                return false;
+            }
+
+            return metadata.GenerationTrigger == ExperimentCompletedGenerationTrigger;
         }
 
         /// <summary>
@@ -83,6 +115,11 @@ namespace AstraLab.Services.AI
             /// Gets or sets the dataset profile identifier used to ground the automatic insight.
             /// </summary>
             public long? DatasetProfileId { get; set; }
+
+            /// <summary>
+            /// Gets or sets the machine learning experiment identifier used to ground the automatic insight.
+            /// </summary>
+            public long? MLExperimentId { get; set; }
         }
     }
 }

--- a/aspnet-core/src/AstraLab.Application/Services/AI/AiAutomaticInsightMetadata.cs
+++ b/aspnet-core/src/AstraLab.Application/Services/AI/AiAutomaticInsightMetadata.cs
@@ -1,0 +1,88 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace AstraLab.Services.AI
+{
+    /// <summary>
+    /// Provides shared metadata helpers for profiling-triggered automatic dataset insights.
+    /// </summary>
+    public static class AiAutomaticInsightMetadata
+    {
+        /// <summary>
+        /// The metadata trigger value used for profiling-completed automatic insights.
+        /// </summary>
+        public const string ProfilingCompletedGenerationTrigger = "profilingCompleted";
+
+        private static readonly JsonSerializerOptions SerializerOptions = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+        };
+
+        /// <summary>
+        /// Determines whether the persisted metadata belongs to an automatic profiling-triggered insight.
+        /// </summary>
+        public static bool IsAutomaticProfilingInsight(string metadataJson, long datasetProfileId)
+        {
+            if (!TryRead(metadataJson, out var metadata))
+            {
+                return false;
+            }
+
+            return metadata.GenerationTrigger == ProfilingCompletedGenerationTrigger &&
+                   metadata.DatasetProfileId == datasetProfileId;
+        }
+
+        /// <summary>
+        /// Determines whether the persisted metadata belongs to any profiling-triggered automatic insight.
+        /// </summary>
+        public static bool IsAutomaticProfilingInsight(string metadataJson)
+        {
+            if (!TryRead(metadataJson, out var metadata))
+            {
+                return false;
+            }
+
+            return metadata.GenerationTrigger == ProfilingCompletedGenerationTrigger;
+        }
+
+        /// <summary>
+        /// Reads automatic insight metadata when it is available and valid.
+        /// </summary>
+        public static bool TryRead(string metadataJson, out AutomaticInsightMetadata metadata)
+        {
+            metadata = null;
+
+            if (string.IsNullOrWhiteSpace(metadataJson))
+            {
+                return false;
+            }
+
+            try
+            {
+                metadata = JsonSerializer.Deserialize<AutomaticInsightMetadata>(metadataJson, SerializerOptions);
+                return metadata != null;
+            }
+            catch (JsonException)
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Represents the automatic-insight metadata fields persisted inside AI response metadata JSON.
+        /// </summary>
+        public class AutomaticInsightMetadata
+        {
+            /// <summary>
+            /// Gets or sets the generation trigger recorded for the response.
+            /// </summary>
+            public string GenerationTrigger { get; set; }
+
+            /// <summary>
+            /// Gets or sets the dataset profile identifier used to ground the automatic insight.
+            /// </summary>
+            public long? DatasetProfileId { get; set; }
+        }
+    }
+}

--- a/aspnet-core/src/AstraLab.Application/Services/AI/AiColumnContext.cs
+++ b/aspnet-core/src/AstraLab.Application/Services/AI/AiColumnContext.cs
@@ -1,0 +1,88 @@
+namespace AstraLab.Services.AI
+{
+    /// <summary>
+    /// Represents the per-column metadata and compact profiling insight included in AI context assembly.
+    /// </summary>
+    public class AiColumnContext
+    {
+        /// <summary>
+        /// Gets or sets the dataset column identifier.
+        /// </summary>
+        public long DatasetColumnId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the column name.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the ordinal position of the column.
+        /// </summary>
+        public int Ordinal { get; set; }
+
+        /// <summary>
+        /// Gets or sets the persisted column data type.
+        /// </summary>
+        public string DataType { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the data type was inferred.
+        /// </summary>
+        public bool IsDataTypeInferred { get; set; }
+
+        /// <summary>
+        /// Gets or sets the persisted null count when known.
+        /// </summary>
+        public long? NullCount { get; set; }
+
+        /// <summary>
+        /// Gets or sets the persisted distinct count when known.
+        /// </summary>
+        public long? DistinctCount { get; set; }
+
+        /// <summary>
+        /// Gets or sets the profiled inferred data type when detailed profiling context is included.
+        /// </summary>
+        public string ProfiledInferredDataType { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether detailed profiling data is included for this column.
+        /// </summary>
+        public bool HasDetailedProfile { get; set; }
+
+        /// <summary>
+        /// Gets or sets the profiled null percentage when detailed profiling context is included.
+        /// </summary>
+        public decimal? NullPercentage { get; set; }
+
+        /// <summary>
+        /// Gets or sets the profiled mean when available.
+        /// </summary>
+        public decimal? Mean { get; set; }
+
+        /// <summary>
+        /// Gets or sets the profiled minimum value when available.
+        /// </summary>
+        public decimal? Min { get; set; }
+
+        /// <summary>
+        /// Gets or sets the profiled maximum value when available.
+        /// </summary>
+        public decimal? Max { get; set; }
+
+        /// <summary>
+        /// Gets or sets the profiled anomaly count when available.
+        /// </summary>
+        public long? AnomalyCount { get; set; }
+
+        /// <summary>
+        /// Gets or sets the profiled anomaly percentage when available.
+        /// </summary>
+        public decimal? AnomalyPercentage { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether anomalies were detected when detailed profiling context is included.
+        /// </summary>
+        public bool? HasAnomalies { get; set; }
+    }
+}

--- a/aspnet-core/src/AstraLab.Application/Services/AI/AiConversationHistoryBuilder.cs
+++ b/aspnet-core/src/AstraLab.Application/Services/AI/AiConversationHistoryBuilder.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+using Abp.Dependency;
+using AstraLab.Core.Domains.AI;
+
+namespace AstraLab.Services.AI
+{
+    /// <summary>
+    /// Builds replayable provider-neutral conversation history from persisted AI responses.
+    /// </summary>
+    public class AiConversationHistoryBuilder : IAiConversationHistoryBuilder, ITransientDependency
+    {
+        /// <summary>
+        /// Builds replayable conversation messages in chronological order.
+        /// </summary>
+        public IReadOnlyList<AiConversationHistoryMessage> Build(IReadOnlyList<AIResponse> responses)
+        {
+            var output = new List<AiConversationHistoryMessage>();
+
+            foreach (var response in responses)
+            {
+                if (!string.IsNullOrWhiteSpace(response.UserQuery))
+                {
+                    output.Add(new AiConversationHistoryMessage
+                    {
+                        Role = "user",
+                        Content = response.UserQuery
+                    });
+                }
+
+                output.Add(new AiConversationHistoryMessage
+                {
+                    Role = "assistant",
+                    Content = response.ResponseContent
+                });
+            }
+
+            return output;
+        }
+    }
+}

--- a/aspnet-core/src/AstraLab.Application/Services/AI/AiConversationHistoryMessage.cs
+++ b/aspnet-core/src/AstraLab.Application/Services/AI/AiConversationHistoryMessage.cs
@@ -1,0 +1,18 @@
+namespace AstraLab.Services.AI
+{
+    /// <summary>
+    /// Represents a single replayable conversation message.
+    /// </summary>
+    public class AiConversationHistoryMessage
+    {
+        /// <summary>
+        /// Gets or sets the provider role name.
+        /// </summary>
+        public string Role { get; set; }
+
+        /// <summary>
+        /// Gets or sets the message content.
+        /// </summary>
+        public string Content { get; set; }
+    }
+}

--- a/aspnet-core/src/AstraLab.Application/Services/AI/AiDatasetContext.cs
+++ b/aspnet-core/src/AstraLab.Application/Services/AI/AiDatasetContext.cs
@@ -1,0 +1,45 @@
+using System.Collections.Generic;
+
+namespace AstraLab.Services.AI
+{
+    /// <summary>
+    /// Represents the structured dataset-version context assembled for future AI workflows.
+    /// </summary>
+    public class AiDatasetContext
+    {
+        /// <summary>
+        /// Gets or sets the dataset-level summary.
+        /// </summary>
+        public AiDatasetSummaryContext Dataset { get; set; }
+
+        /// <summary>
+        /// Gets or sets the selected dataset version summary.
+        /// </summary>
+        public AiDatasetVersionContext Version { get; set; }
+
+        /// <summary>
+        /// Gets or sets the schema-level summary.
+        /// </summary>
+        public AiSchemaContext Schema { get; set; }
+
+        /// <summary>
+        /// Gets or sets the dataset-level profiling summary when available.
+        /// </summary>
+        public AiProfilingContext Profiling { get; set; }
+
+        /// <summary>
+        /// Gets or sets the ordered column context collection.
+        /// </summary>
+        public IReadOnlyList<AiColumnContext> Columns { get; set; }
+
+        /// <summary>
+        /// Gets or sets the number of columns that retained detailed profiling context.
+        /// </summary>
+        public int DetailedColumnCount { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether detailed column context was pruned for token control.
+        /// </summary>
+        public bool IsColumnContextPruned { get; set; }
+    }
+}

--- a/aspnet-core/src/AstraLab.Application/Services/AI/AiDatasetContextBuilder.cs
+++ b/aspnet-core/src/AstraLab.Application/Services/AI/AiDatasetContextBuilder.cs
@@ -1,0 +1,413 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Abp.Dependency;
+using Abp.Domain.Repositories;
+using AstraLab.Core.Domains.Datasets;
+using AstraLab.Services.Datasets;
+using AstraLab.Services.Datasets.Profiling;
+using Microsoft.EntityFrameworkCore;
+
+namespace AstraLab.Services.AI
+{
+    /// <summary>
+    /// Builds a structured dataset context from persisted dataset metadata and profiling results.
+    /// </summary>
+    public class AiDatasetContextBuilder : AstraLabAppServiceBase, IAiDatasetContextBuilder, ITransientDependency
+    {
+        private readonly IRepository<Dataset, long> _datasetRepository;
+        private readonly IRepository<DatasetColumn, long> _datasetColumnRepository;
+        private readonly IRepository<DatasetProfile, long> _datasetProfileRepository;
+        private readonly IRepository<DatasetColumnProfile, long> _datasetColumnProfileRepository;
+        private readonly IDatasetOwnershipAccessChecker _datasetOwnershipAccessChecker;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AiDatasetContextBuilder"/> class.
+        /// </summary>
+        public AiDatasetContextBuilder(
+            IRepository<Dataset, long> datasetRepository,
+            IRepository<DatasetColumn, long> datasetColumnRepository,
+            IRepository<DatasetProfile, long> datasetProfileRepository,
+            IRepository<DatasetColumnProfile, long> datasetColumnProfileRepository,
+            IDatasetOwnershipAccessChecker datasetOwnershipAccessChecker)
+        {
+            _datasetRepository = datasetRepository;
+            _datasetColumnRepository = datasetColumnRepository;
+            _datasetProfileRepository = datasetProfileRepository;
+            _datasetColumnProfileRepository = datasetColumnProfileRepository;
+            _datasetOwnershipAccessChecker = datasetOwnershipAccessChecker;
+        }
+
+        /// <summary>
+        /// Builds structured dataset context for the specified owner-scoped dataset version.
+        /// </summary>
+        public async Task<AiDatasetContext> BuildAsync(long datasetVersionId, int tenantId, long ownerUserId)
+        {
+            var datasetVersion = await _datasetOwnershipAccessChecker.GetDatasetVersionForOwnerAsync(datasetVersionId, tenantId, ownerUserId);
+            var dataset = await GetDatasetAsync(datasetVersion.DatasetId, tenantId, ownerUserId);
+            var columns = await GetColumnsAsync(datasetVersionId, tenantId);
+            var datasetProfile = await GetDatasetProfileAsync(datasetVersionId, tenantId);
+            var columnProfiles = datasetProfile == null
+                ? new List<ColumnProfileRecord>()
+                : await GetColumnProfilesAsync(datasetProfile.ProfileId, tenantId, columns);
+
+            var detailedColumnIds = GetDetailedColumnIds(columns.Count, columnProfiles);
+            var columnContexts = BuildColumnContexts(columns, columnProfiles, detailedColumnIds);
+
+            return new AiDatasetContext
+            {
+                Dataset = BuildDatasetSummary(dataset),
+                Version = BuildDatasetVersionSummary(datasetVersion),
+                Schema = BuildSchemaSummary(datasetVersion, columns.Count),
+                Profiling = BuildProfilingSummary(datasetProfile),
+                Columns = columnContexts,
+                DetailedColumnCount = detailedColumnIds.Count,
+                IsColumnContextPruned = columns.Count > AiDatasetContextDefaults.MaxColumnsWithFullDetail
+            };
+        }
+
+        /// <summary>
+        /// Gets the dataset scoped to the current owner and tenant.
+        /// </summary>
+        private async Task<Dataset> GetDatasetAsync(long datasetId, int tenantId, long ownerUserId)
+        {
+            return await _datasetRepository.GetAll()
+                .Where(item => item.Id == datasetId && item.TenantId == tenantId && item.OwnerUserId == ownerUserId)
+                .SingleAsync();
+        }
+
+        /// <summary>
+        /// Gets the persisted columns for the selected dataset version.
+        /// </summary>
+        private async Task<List<ColumnRecord>> GetColumnsAsync(long datasetVersionId, int tenantId)
+        {
+            return await _datasetColumnRepository.GetAll()
+                .Where(item => item.TenantId == tenantId && item.DatasetVersionId == datasetVersionId)
+                .OrderBy(item => item.Ordinal)
+                .Select(item => new ColumnRecord
+                {
+                    DatasetColumnId = item.Id,
+                    Name = item.Name,
+                    Ordinal = item.Ordinal,
+                    DataType = item.DataType,
+                    IsDataTypeInferred = item.IsDataTypeInferred,
+                    NullCount = item.NullCount,
+                    DistinctCount = item.DistinctCount
+                })
+                .ToListAsync();
+        }
+
+        /// <summary>
+        /// Gets the persisted dataset-level profile when available.
+        /// </summary>
+        private async Task<DatasetProfileRecord> GetDatasetProfileAsync(long datasetVersionId, int tenantId)
+        {
+            return await _datasetProfileRepository.GetAll()
+                .Where(item => item.TenantId == tenantId && item.DatasetVersionId == datasetVersionId)
+                .Select(item => new DatasetProfileRecord
+                {
+                    ProfileId = item.Id,
+                    RowCount = item.RowCount,
+                    DuplicateRowCount = item.DuplicateRowCount,
+                    DataHealthScore = item.DataHealthScore,
+                    SummaryJson = item.SummaryJson,
+                    CreationTime = item.CreationTime
+                })
+                .FirstOrDefaultAsync();
+        }
+
+        /// <summary>
+        /// Gets the persisted column-level profile rows for the selected dataset profile.
+        /// </summary>
+        private async Task<List<ColumnProfileRecord>> GetColumnProfilesAsync(long datasetProfileId, int tenantId, IReadOnlyCollection<ColumnRecord> columns)
+        {
+            var ordinals = columns.ToDictionary(item => item.DatasetColumnId, item => item.Ordinal);
+
+            return (await _datasetColumnProfileRepository.GetAll()
+                    .Where(item => item.TenantId == tenantId && item.DatasetProfileId == datasetProfileId)
+                    .Select(item => new ColumnProfileRecord
+                    {
+                        DatasetColumnId = item.DatasetColumnId,
+                        InferredDataType = item.InferredDataType,
+                        NullCount = item.NullCount,
+                        DistinctCount = item.DistinctCount,
+                        StatisticsJson = item.StatisticsJson
+                    })
+                    .ToListAsync())
+                .Select(item =>
+                {
+                    item.Ordinal = ordinals.TryGetValue(item.DatasetColumnId, out var ordinal) ? ordinal : int.MaxValue;
+                    return item;
+                })
+                .ToList();
+        }
+
+        /// <summary>
+        /// Chooses which columns should retain detailed profiling context when the dataset is wide.
+        /// </summary>
+        private static HashSet<long> GetDetailedColumnIds(int totalColumnCount, IReadOnlyCollection<ColumnProfileRecord> columnProfiles)
+        {
+            if (totalColumnCount <= AiDatasetContextDefaults.MaxColumnsWithFullDetail)
+            {
+                return columnProfiles.Select(item => item.DatasetColumnId).ToHashSet();
+            }
+
+            return columnProfiles
+                .Select(BuildColumnProfileRanking)
+                .OrderByDescending(item => item.Score)
+                .ThenBy(item => item.Ordinal)
+                .Take(AiDatasetContextDefaults.MaxProfiledColumnsInCompactSummary)
+                .Select(item => item.DatasetColumnId)
+                .ToHashSet();
+        }
+
+        /// <summary>
+        /// Builds the column context collection using base metadata for all columns and detailed profiling for the selected subset.
+        /// </summary>
+        private static IReadOnlyList<AiColumnContext> BuildColumnContexts(
+            IReadOnlyCollection<ColumnRecord> columns,
+            IReadOnlyCollection<ColumnProfileRecord> columnProfiles,
+            IReadOnlySet<long> detailedColumnIds)
+        {
+            var profileLookup = columnProfiles.ToDictionary(item => item.DatasetColumnId);
+
+            return columns
+                .OrderBy(item => item.Ordinal)
+                .Select(item =>
+                {
+                    profileLookup.TryGetValue(item.DatasetColumnId, out var profile);
+                    return BuildColumnContext(item, profile, detailedColumnIds.Contains(item.DatasetColumnId));
+                })
+                .ToList();
+        }
+
+        /// <summary>
+        /// Builds the dataset summary context.
+        /// </summary>
+        private static AiDatasetSummaryContext BuildDatasetSummary(Dataset dataset)
+        {
+            var compactDescription = Truncate(dataset.Description, AiDatasetContextDefaults.MaxDatasetDescriptionLength);
+            var compactOriginalFileName = Truncate(dataset.OriginalFileName, AiDatasetContextDefaults.MaxOriginalFileNameLength);
+
+            return new AiDatasetSummaryContext
+            {
+                DatasetId = dataset.Id,
+                Name = dataset.Name,
+                Description = compactDescription.Value,
+                DescriptionWasTruncated = compactDescription.WasTruncated,
+                SourceFormat = dataset.SourceFormat,
+                Status = dataset.Status,
+                OwnerUserId = dataset.OwnerUserId,
+                OriginalFileName = compactOriginalFileName.Value,
+                OriginalFileNameWasTruncated = compactOriginalFileName.WasTruncated,
+                CreationTime = dataset.CreationTime
+            };
+        }
+
+        /// <summary>
+        /// Builds the dataset version summary context.
+        /// </summary>
+        private static AiDatasetVersionContext BuildDatasetVersionSummary(DatasetVersion datasetVersion)
+        {
+            return new AiDatasetVersionContext
+            {
+                DatasetVersionId = datasetVersion.Id,
+                DatasetId = datasetVersion.DatasetId,
+                VersionNumber = datasetVersion.VersionNumber,
+                VersionType = datasetVersion.VersionType,
+                Status = datasetVersion.Status,
+                ParentVersionId = datasetVersion.ParentVersionId,
+                RowCount = datasetVersion.RowCount,
+                ColumnCount = datasetVersion.ColumnCount,
+                SizeBytes = datasetVersion.SizeBytes,
+                CreationTime = datasetVersion.CreationTime
+            };
+        }
+
+        /// <summary>
+        /// Builds the schema summary context.
+        /// </summary>
+        private static AiSchemaContext BuildSchemaSummary(DatasetVersion datasetVersion, int totalColumnCount)
+        {
+            var schemaPreview = Truncate(datasetVersion.SchemaJson, AiDatasetContextDefaults.MaxSchemaPreviewLength);
+
+            return new AiSchemaContext
+            {
+                TotalColumnCount = totalColumnCount,
+                HasSchemaJson = !string.IsNullOrWhiteSpace(datasetVersion.SchemaJson),
+                SchemaJsonPreview = schemaPreview.Value,
+                SchemaJsonWasTruncated = schemaPreview.WasTruncated
+            };
+        }
+
+        /// <summary>
+        /// Builds the dataset-level profiling summary context when a profile exists.
+        /// </summary>
+        private static AiProfilingContext BuildProfilingSummary(DatasetProfileRecord datasetProfile)
+        {
+            if (datasetProfile == null)
+            {
+                return null;
+            }
+
+            var summary = DatasetProfileSerialization.ReadSummary(datasetProfile.SummaryJson);
+            return new AiProfilingContext
+            {
+                ProfileId = datasetProfile.ProfileId,
+                RowCount = datasetProfile.RowCount,
+                DuplicateRowCount = datasetProfile.DuplicateRowCount,
+                DataHealthScore = datasetProfile.DataHealthScore,
+                TotalNullCount = summary.TotalNullCount,
+                OverallNullPercentage = summary.OverallNullPercentage,
+                TotalAnomalyCount = summary.TotalAnomalyCount,
+                OverallAnomalyPercentage = summary.OverallAnomalyPercentage,
+                CreationTime = datasetProfile.CreationTime
+            };
+        }
+
+        /// <summary>
+        /// Builds a single column context row using base metadata and optional detailed profiling data.
+        /// </summary>
+        private static AiColumnContext BuildColumnContext(ColumnRecord column, ColumnProfileRecord columnProfile, bool includeDetailedProfile)
+        {
+            var context = new AiColumnContext
+            {
+                DatasetColumnId = column.DatasetColumnId,
+                Name = column.Name,
+                Ordinal = column.Ordinal,
+                DataType = column.DataType,
+                IsDataTypeInferred = column.IsDataTypeInferred,
+                NullCount = column.NullCount ?? columnProfile?.NullCount,
+                DistinctCount = column.DistinctCount ?? columnProfile?.DistinctCount,
+                HasDetailedProfile = includeDetailedProfile && columnProfile != null
+            };
+
+            if (!context.HasDetailedProfile)
+            {
+                return context;
+            }
+
+            var statistics = DatasetProfileSerialization.ReadColumnStatistics(columnProfile.StatisticsJson);
+            context.ProfiledInferredDataType = columnProfile.InferredDataType;
+            context.NullPercentage = statistics.NullPercentage;
+            context.Mean = statistics.Mean;
+            context.Min = statistics.Min;
+            context.Max = statistics.Max;
+            context.AnomalyCount = statistics.AnomalyCount;
+            context.AnomalyPercentage = statistics.AnomalyPercentage;
+            context.HasAnomalies = statistics.HasAnomalies;
+
+            return context;
+        }
+
+        /// <summary>
+        /// Builds a deterministic ranking used to keep the most informative profiled columns in compact mode.
+        /// </summary>
+        private static ColumnProfileRanking BuildColumnProfileRanking(ColumnProfileRecord columnProfile)
+        {
+            var statistics = DatasetProfileSerialization.ReadColumnStatistics(columnProfile.StatisticsJson);
+            decimal score = 0m;
+
+            if (statistics.HasAnomalies)
+            {
+                score += 100000m;
+                score += statistics.AnomalyPercentage * 100m;
+                score += statistics.AnomalyCount;
+            }
+
+            score += statistics.NullPercentage * 1000m;
+
+            if (columnProfile.DistinctCount.HasValue)
+            {
+                score += Math.Min(columnProfile.DistinctCount.Value, 1000L) / 10m;
+            }
+
+            if (statistics.Mean.HasValue || statistics.Min.HasValue || statistics.Max.HasValue)
+            {
+                score += 25m;
+            }
+
+            if (string.Equals(columnProfile.InferredDataType, "integer", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(columnProfile.InferredDataType, "decimal", StringComparison.OrdinalIgnoreCase))
+            {
+                score += 10m;
+            }
+
+            return new ColumnProfileRanking
+            {
+                DatasetColumnId = columnProfile.DatasetColumnId,
+                Ordinal = columnProfile.Ordinal,
+                Score = score
+            };
+        }
+
+        /// <summary>
+        /// Produces a compact text fragment and indicates whether truncation was required.
+        /// </summary>
+        private static (string Value, bool WasTruncated) Truncate(string value, int maxLength)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return (null, false);
+            }
+
+            if (value.Length <= maxLength)
+            {
+                return (value, false);
+            }
+
+            return (value.Substring(0, maxLength), true);
+        }
+
+        /// <summary>
+        /// Represents the projected dataset profile shape needed by the context builder.
+        /// </summary>
+        private class DatasetProfileRecord
+        {
+            public long ProfileId { get; set; }
+            public long RowCount { get; set; }
+            public long DuplicateRowCount { get; set; }
+            public decimal DataHealthScore { get; set; }
+            public string SummaryJson { get; set; }
+            public DateTime CreationTime { get; set; }
+        }
+
+        /// <summary>
+        /// Represents the projected dataset column shape needed by the context builder.
+        /// </summary>
+        private class ColumnRecord
+        {
+            public long DatasetColumnId { get; set; }
+            public string Name { get; set; }
+            public int Ordinal { get; set; }
+            public string DataType { get; set; }
+            public bool IsDataTypeInferred { get; set; }
+            public long? NullCount { get; set; }
+            public long? DistinctCount { get; set; }
+        }
+
+        /// <summary>
+        /// Represents the projected column profile shape needed by the context builder.
+        /// </summary>
+        private class ColumnProfileRecord
+        {
+            public long DatasetColumnId { get; set; }
+            public string InferredDataType { get; set; }
+            public long NullCount { get; set; }
+            public long? DistinctCount { get; set; }
+            public string StatisticsJson { get; set; }
+            public int Ordinal { get; set; }
+        }
+
+        /// <summary>
+        /// Represents the deterministic ranking result used during compact-mode pruning.
+        /// </summary>
+        private class ColumnProfileRanking
+        {
+            public long DatasetColumnId { get; set; }
+            public int Ordinal { get; set; }
+            public decimal Score { get; set; }
+        }
+    }
+}

--- a/aspnet-core/src/AstraLab.Application/Services/AI/AiDatasetContextDefaults.cs
+++ b/aspnet-core/src/AstraLab.Application/Services/AI/AiDatasetContextDefaults.cs
@@ -1,0 +1,33 @@
+namespace AstraLab.Services.AI
+{
+    /// <summary>
+    /// Defines the default limits used when shaping dataset context for future AI workflows.
+    /// </summary>
+    public static class AiDatasetContextDefaults
+    {
+        /// <summary>
+        /// The maximum number of columns that can receive full profiling detail before pruning is applied.
+        /// </summary>
+        public const int MaxColumnsWithFullDetail = 20;
+
+        /// <summary>
+        /// The maximum number of columns that can retain detailed profiling insights in compact mode.
+        /// </summary>
+        public const int MaxProfiledColumnsInCompactSummary = 8;
+
+        /// <summary>
+        /// The maximum number of characters kept from dataset descriptions.
+        /// </summary>
+        public const int MaxDatasetDescriptionLength = 400;
+
+        /// <summary>
+        /// The maximum number of characters kept from serialized schema payloads.
+        /// </summary>
+        public const int MaxSchemaPreviewLength = 1200;
+
+        /// <summary>
+        /// The maximum number of characters kept from original file names in compact context summaries.
+        /// </summary>
+        public const int MaxOriginalFileNameLength = 200;
+    }
+}

--- a/aspnet-core/src/AstraLab.Application/Services/AI/AiDatasetGenerationDefaults.cs
+++ b/aspnet-core/src/AstraLab.Application/Services/AI/AiDatasetGenerationDefaults.cs
@@ -1,0 +1,23 @@
+namespace AstraLab.Services.AI
+{
+    /// <summary>
+    /// Defines reusable defaults for dataset AI prompting and enrichment.
+    /// </summary>
+    public static class AiDatasetGenerationDefaults
+    {
+        /// <summary>
+        /// The maximum number of high-signal columns included in enrichment payloads.
+        /// </summary>
+        public const int MaxHighSignalColumns = 5;
+
+        /// <summary>
+        /// The maximum number of recent transformations included in enrichment payloads.
+        /// </summary>
+        public const int MaxRecentTransformations = 5;
+
+        /// <summary>
+        /// The maximum number of prior assistant turns replayed into Q&amp;A prompts.
+        /// </summary>
+        public const int MaxConversationResponses = 12;
+    }
+}

--- a/aspnet-core/src/AstraLab.Application/Services/AI/AiDatasetInsightContext.cs
+++ b/aspnet-core/src/AstraLab.Application/Services/AI/AiDatasetInsightContext.cs
@@ -1,0 +1,55 @@
+using System.Collections.Generic;
+
+namespace AstraLab.Services.AI
+{
+    /// <summary>
+    /// Represents compact read-only enrichment data for dataset AI prompts.
+    /// </summary>
+    public class AiDatasetInsightContext
+    {
+        /// <summary>
+        /// Gets or sets the dataset version identifier that produced the enrichment.
+        /// </summary>
+        public long DatasetVersionId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the optional data health score.
+        /// </summary>
+        public decimal? DataHealthScore { get; set; }
+
+        /// <summary>
+        /// Gets or sets the optional duplicate row count.
+        /// </summary>
+        public long? DuplicateRowCount { get; set; }
+
+        /// <summary>
+        /// Gets or sets the optional total null count.
+        /// </summary>
+        public long? TotalNullCount { get; set; }
+
+        /// <summary>
+        /// Gets or sets the optional overall null percentage.
+        /// </summary>
+        public decimal? OverallNullPercentage { get; set; }
+
+        /// <summary>
+        /// Gets or sets the optional total anomaly count.
+        /// </summary>
+        public long? TotalAnomalyCount { get; set; }
+
+        /// <summary>
+        /// Gets or sets the optional overall anomaly percentage.
+        /// </summary>
+        public decimal? OverallAnomalyPercentage { get; set; }
+
+        /// <summary>
+        /// Gets or sets the high-signal column insights.
+        /// </summary>
+        public IReadOnlyList<AiInsightColumnContext> HighSignalColumns { get; set; }
+
+        /// <summary>
+        /// Gets or sets the recent transformation history for the current version lineage.
+        /// </summary>
+        public IReadOnlyList<AiTransformationHistoryContext> RecentTransformations { get; set; }
+    }
+}

--- a/aspnet-core/src/AstraLab.Application/Services/AI/AiDatasetInsightReader.cs
+++ b/aspnet-core/src/AstraLab.Application/Services/AI/AiDatasetInsightReader.cs
@@ -1,0 +1,251 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Abp.Dependency;
+using Abp.Domain.Repositories;
+using AstraLab.Core.Domains.Datasets;
+using AstraLab.Services.Datasets;
+using AstraLab.Services.Datasets.Profiling;
+using Microsoft.EntityFrameworkCore;
+
+namespace AstraLab.Services.AI
+{
+    /// <summary>
+    /// Loads compact high-signal enrichment data from persisted profiling and transformation records.
+    /// </summary>
+    public class AiDatasetInsightReader : AstraLabAppServiceBase, IAiDatasetInsightReader, ITransientDependency
+    {
+        private readonly IRepository<DatasetVersion, long> _datasetVersionRepository;
+        private readonly IRepository<DatasetProfile, long> _datasetProfileRepository;
+        private readonly IRepository<DatasetColumn, long> _datasetColumnRepository;
+        private readonly IRepository<DatasetColumnProfile, long> _datasetColumnProfileRepository;
+        private readonly IRepository<DatasetTransformation, long> _datasetTransformationRepository;
+        private readonly IDatasetOwnershipAccessChecker _datasetOwnershipAccessChecker;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AiDatasetInsightReader"/> class.
+        /// </summary>
+        public AiDatasetInsightReader(
+            IRepository<DatasetVersion, long> datasetVersionRepository,
+            IRepository<DatasetProfile, long> datasetProfileRepository,
+            IRepository<DatasetColumn, long> datasetColumnRepository,
+            IRepository<DatasetColumnProfile, long> datasetColumnProfileRepository,
+            IRepository<DatasetTransformation, long> datasetTransformationRepository,
+            IDatasetOwnershipAccessChecker datasetOwnershipAccessChecker)
+        {
+            _datasetVersionRepository = datasetVersionRepository;
+            _datasetProfileRepository = datasetProfileRepository;
+            _datasetColumnRepository = datasetColumnRepository;
+            _datasetColumnProfileRepository = datasetColumnProfileRepository;
+            _datasetTransformationRepository = datasetTransformationRepository;
+            _datasetOwnershipAccessChecker = datasetOwnershipAccessChecker;
+        }
+
+        /// <summary>
+        /// Reads compact enrichment context for the specified dataset version.
+        /// </summary>
+        public async Task<AiDatasetInsightContext> ReadAsync(long datasetVersionId, int tenantId, long ownerUserId)
+        {
+            var datasetVersion = await _datasetOwnershipAccessChecker.GetDatasetVersionForOwnerAsync(datasetVersionId, tenantId, ownerUserId);
+            var datasetProfile = await GetDatasetProfileAsync(datasetVersionId, tenantId);
+            var highSignalColumns = datasetProfile == null
+                ? new List<AiInsightColumnContext>()
+                : await GetHighSignalColumnsAsync(datasetProfile.Id, datasetVersionId, tenantId);
+            var recentTransformations = await GetRecentTransformationsAsync(datasetVersion, tenantId);
+
+            var summary = datasetProfile == null
+                ? (TotalNullCount: 0L, OverallNullPercentage: 0m, TotalAnomalyCount: 0L, OverallAnomalyPercentage: 0m)
+                : DatasetProfileSerialization.ReadSummary(datasetProfile.SummaryJson);
+
+            return new AiDatasetInsightContext
+            {
+                DatasetVersionId = datasetVersionId,
+                DataHealthScore = datasetProfile?.DataHealthScore,
+                DuplicateRowCount = datasetProfile?.DuplicateRowCount,
+                TotalNullCount = datasetProfile == null ? null : summary.TotalNullCount,
+                OverallNullPercentage = datasetProfile == null ? null : summary.OverallNullPercentage,
+                TotalAnomalyCount = datasetProfile == null ? null : summary.TotalAnomalyCount,
+                OverallAnomalyPercentage = datasetProfile == null ? null : summary.OverallAnomalyPercentage,
+                HighSignalColumns = highSignalColumns,
+                RecentTransformations = recentTransformations
+            };
+        }
+
+        /// <summary>
+        /// Gets the persisted dataset-level profile when one exists.
+        /// </summary>
+        private async Task<DatasetProfile> GetDatasetProfileAsync(long datasetVersionId, int tenantId)
+        {
+            return await _datasetProfileRepository.GetAll()
+                .Where(item => item.TenantId == tenantId && item.DatasetVersionId == datasetVersionId)
+                .FirstOrDefaultAsync();
+        }
+
+        /// <summary>
+        /// Gets the highest-signal profiled columns for prompt enrichment.
+        /// </summary>
+        private async Task<IReadOnlyList<AiInsightColumnContext>> GetHighSignalColumnsAsync(long datasetProfileId, long datasetVersionId, int tenantId)
+        {
+            var columnProfiles = await (
+                    from columnProfile in _datasetColumnProfileRepository.GetAll()
+                    join datasetColumn in _datasetColumnRepository.GetAll()
+                        on columnProfile.DatasetColumnId equals datasetColumn.Id
+                    where columnProfile.TenantId == tenantId &&
+                          columnProfile.DatasetProfileId == datasetProfileId &&
+                          datasetColumn.DatasetVersionId == datasetVersionId
+                    select new ColumnInsightRecord
+                    {
+                        DatasetColumnId = datasetColumn.Id,
+                        Name = datasetColumn.Name,
+                        Ordinal = datasetColumn.Ordinal,
+                        DataType = columnProfile.InferredDataType ?? datasetColumn.DataType,
+                        NullCount = columnProfile.NullCount,
+                        DistinctCount = columnProfile.DistinctCount,
+                        StatisticsJson = columnProfile.StatisticsJson
+                    })
+                .ToListAsync();
+
+            return columnProfiles
+                .Select(MapColumnInsight)
+                .OrderByDescending(item => item.Score)
+                .ThenBy(item => item.Ordinal)
+                .Take(AiDatasetGenerationDefaults.MaxHighSignalColumns)
+                .Select(item => item.Context)
+                .ToList();
+        }
+
+        /// <summary>
+        /// Gets recent transformation history from the selected version lineage.
+        /// </summary>
+        private async Task<IReadOnlyList<AiTransformationHistoryContext>> GetRecentTransformationsAsync(DatasetVersion datasetVersion, int tenantId)
+        {
+            var lineageVersionIds = await GetLineageVersionIdsAsync(datasetVersion, tenantId);
+
+            return await _datasetTransformationRepository.GetAll()
+                .Where(item =>
+                    item.TenantId == tenantId &&
+                    (lineageVersionIds.Contains(item.SourceDatasetVersionId) ||
+                     (item.ResultDatasetVersionId.HasValue && lineageVersionIds.Contains(item.ResultDatasetVersionId.Value))))
+                .OrderByDescending(item => item.ExecutedAt)
+                .ThenByDescending(item => item.Id)
+                .Take(AiDatasetGenerationDefaults.MaxRecentTransformations)
+                .Select(item => new AiTransformationHistoryContext
+                {
+                    DatasetTransformationId = item.Id,
+                    TransformationType = item.TransformationType,
+                    SourceDatasetVersionId = item.SourceDatasetVersionId,
+                    ResultDatasetVersionId = item.ResultDatasetVersionId,
+                    ExecutionOrder = item.ExecutionOrder,
+                    ExecutedAt = item.ExecutedAt,
+                    SummaryJson = item.SummaryJson
+                })
+                .ToListAsync();
+        }
+
+        /// <summary>
+        /// Resolves the selected version together with its ancestors inside the same dataset.
+        /// </summary>
+        private async Task<HashSet<long>> GetLineageVersionIdsAsync(DatasetVersion datasetVersion, int tenantId)
+        {
+            var versionGraph = await _datasetVersionRepository.GetAll()
+                .Where(item => item.TenantId == tenantId && item.DatasetId == datasetVersion.DatasetId)
+                .Select(item => new
+                {
+                    item.Id,
+                    item.ParentVersionId
+                })
+                .ToListAsync();
+
+            var parentLookup = versionGraph.ToDictionary(item => item.Id, item => item.ParentVersionId);
+            var output = new HashSet<long>();
+            long? currentVersionId = datasetVersion.Id;
+
+            while (currentVersionId.HasValue && output.Add(currentVersionId.Value))
+            {
+                currentVersionId = parentLookup.TryGetValue(currentVersionId.Value, out var parentVersionId)
+                    ? parentVersionId
+                    : null;
+            }
+
+            return output;
+        }
+
+        /// <summary>
+        /// Maps a profiled column row into a ranked high-signal column context.
+        /// </summary>
+        private static RankedColumnInsight MapColumnInsight(ColumnInsightRecord record)
+        {
+            var statistics = DatasetProfileSerialization.ReadColumnStatistics(record.StatisticsJson);
+            decimal score = (statistics.NullPercentage * 1000m) + (statistics.AnomalyPercentage * 100m);
+
+            if (statistics.HasAnomalies)
+            {
+                score += 100000m;
+            }
+
+            if (record.DistinctCount.HasValue)
+            {
+                score += Math.Min(record.DistinctCount.Value, 1000L) / 10m;
+            }
+
+            if (statistics.Mean.HasValue || statistics.Min.HasValue || statistics.Max.HasValue)
+            {
+                score += 25m;
+            }
+
+            return new RankedColumnInsight
+            {
+                Ordinal = record.Ordinal,
+                Score = score,
+                Context = new AiInsightColumnContext
+                {
+                    DatasetColumnId = record.DatasetColumnId,
+                    Name = record.Name,
+                    DataType = record.DataType,
+                    NullCount = record.NullCount,
+                    NullPercentage = statistics.NullPercentage,
+                    DistinctCount = record.DistinctCount,
+                    HasAnomalies = statistics.HasAnomalies,
+                    AnomalyCount = statistics.AnomalyCount,
+                    AnomalyPercentage = statistics.AnomalyPercentage,
+                    Mean = statistics.Mean,
+                    Min = statistics.Min,
+                    Max = statistics.Max
+                }
+            };
+        }
+
+        /// <summary>
+        /// Represents the compact column data projected from the database.
+        /// </summary>
+        private class ColumnInsightRecord
+        {
+            public long DatasetColumnId { get; set; }
+
+            public string Name { get; set; }
+
+            public int Ordinal { get; set; }
+
+            public string DataType { get; set; }
+
+            public long NullCount { get; set; }
+
+            public long? DistinctCount { get; set; }
+
+            public string StatisticsJson { get; set; }
+        }
+
+        /// <summary>
+        /// Represents the ranked high-signal column result.
+        /// </summary>
+        private class RankedColumnInsight
+        {
+            public int Ordinal { get; set; }
+
+            public decimal Score { get; set; }
+
+            public AiInsightColumnContext Context { get; set; }
+        }
+    }
+}

--- a/aspnet-core/src/AstraLab.Application/Services/AI/AiDatasetResponseGenerator.cs
+++ b/aspnet-core/src/AstraLab.Application/Services/AI/AiDatasetResponseGenerator.cs
@@ -90,7 +90,8 @@ namespace AstraLab.Services.AI
                 ResponseType = responseType,
                 DatasetContext = datasetContext,
                 EnrichmentContext = enrichmentContext,
-                UserQuestion = userQuery
+                UserQuestion = userQuery,
+                IsAutomaticProfilingInsight = false
             });
 
             var generatedText = await _aiTextGenerationClient.GenerateTextAsync(new AiTextGenerationRequest
@@ -121,7 +122,13 @@ namespace AstraLab.Services.AI
                 UserQuery = string.IsNullOrWhiteSpace(userQuery) ? null : userQuery.Trim(),
                 ResponseContent = generatedText.Text.Trim(),
                 ResponseType = responseType,
-                MetadataJson = BuildMetadataJson(generatedText, datasetContext, enrichmentContext, conversationHistory.Count)
+                MetadataJson = BuildMetadataJson(
+                    generatedText,
+                    datasetContext,
+                    enrichmentContext,
+                    conversationHistory.Count,
+                    null,
+                    null)
             });
 
             persistedConversation.LastInteractionTime = DateTime.UtcNow;
@@ -130,6 +137,73 @@ namespace AstraLab.Services.AI
             return new GenerateDatasetAiResponseResult
             {
                 ConversationId = persistedConversation.Id,
+                Response = ObjectMapper.Map<AIResponseDto>(response)
+            };
+        }
+
+        /// <summary>
+        /// Generates and persists a profiling-triggered automatic insight for the selected dataset version.
+        /// </summary>
+        public async Task<GenerateDatasetAiResponseResult> GenerateAutomaticInsightAsync(
+            long datasetVersionId,
+            long datasetProfileId,
+            int tenantId,
+            long ownerUserId)
+        {
+            var datasetVersion = await _datasetOwnershipAccessChecker.GetDatasetVersionForOwnerAsync(datasetVersionId, tenantId, ownerUserId);
+            var datasetContext = await _aiDatasetContextBuilder.BuildAsync(datasetVersionId, tenantId, ownerUserId);
+            var enrichmentContext = await _aiDatasetInsightReader.ReadAsync(datasetVersionId, tenantId, ownerUserId);
+            var prompt = _aiPromptBuilder.Build(new AiPromptBuildRequest
+            {
+                ResponseType = AIResponseType.Insight,
+                DatasetContext = datasetContext,
+                EnrichmentContext = enrichmentContext,
+                IsAutomaticProfilingInsight = true
+            });
+
+            var generatedText = await _aiTextGenerationClient.GenerateTextAsync(new AiTextGenerationRequest
+            {
+                SystemInstructions = prompt.SystemInstructions,
+                ConversationHistory = new List<AiConversationHistoryMessage>(),
+                UserMessage = prompt.UserMessage
+            });
+
+            if (string.IsNullOrWhiteSpace(generatedText.Text))
+            {
+                throw new UserFriendlyException("The AI provider did not return usable response text.");
+            }
+
+            var conversation = await _aiConversationRepository.InsertAsync(new AIConversation
+            {
+                TenantId = tenantId,
+                DatasetId = datasetVersion.DatasetId,
+                OwnerUserId = ownerUserId,
+                LastInteractionTime = DateTime.UtcNow
+            });
+
+            var response = await _aiResponseRepository.InsertAsync(new AIResponse
+            {
+                TenantId = tenantId,
+                AIConversation = conversation,
+                DatasetVersionId = datasetVersionId,
+                UserQuery = null,
+                ResponseContent = generatedText.Text.Trim(),
+                ResponseType = AIResponseType.Insight,
+                MetadataJson = BuildMetadataJson(
+                    generatedText,
+                    datasetContext,
+                    enrichmentContext,
+                    0,
+                    AiAutomaticInsightMetadata.ProfilingCompletedGenerationTrigger,
+                    datasetProfileId)
+            });
+
+            conversation.LastInteractionTime = DateTime.UtcNow;
+            await CurrentUnitOfWork.SaveChangesAsync();
+
+            return new GenerateDatasetAiResponseResult
+            {
+                ConversationId = conversation.Id,
                 Response = ObjectMapper.Map<AIResponseDto>(response)
             };
         }
@@ -206,10 +280,14 @@ namespace AstraLab.Services.AI
             AiTextGenerationResult result,
             AiDatasetContext datasetContext,
             AiDatasetInsightContext enrichmentContext,
-            int replayedMessageCount)
+            int replayedMessageCount,
+            string generationTrigger,
+            long? datasetProfileId)
         {
             return JsonSerializer.Serialize(new
             {
+                generationTrigger,
+                datasetProfileId,
                 provider = result.Provider,
                 model = result.Model,
                 providerResponseId = result.ProviderResponseId,

--- a/aspnet-core/src/AstraLab.Application/Services/AI/AiDatasetResponseGenerator.cs
+++ b/aspnet-core/src/AstraLab.Application/Services/AI/AiDatasetResponseGenerator.cs
@@ -1,5 +1,5 @@
-using System.Collections.Generic;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -9,6 +9,7 @@ using Abp.Domain.Repositories;
 using Abp.UI;
 using AstraLab.Core.Domains.AI;
 using AstraLab.Core.Domains.Datasets;
+using AstraLab.Core.Domains.ML;
 using AstraLab.Services.AI.Dto;
 using AstraLab.Services.Datasets;
 using Microsoft.EntityFrameworkCore;
@@ -16,7 +17,7 @@ using Microsoft.EntityFrameworkCore;
 namespace AstraLab.Services.AI
 {
     /// <summary>
-    /// Orchestrates grounded dataset AI generation, conversation replay, and persistence.
+    /// Orchestrates grounded dataset and experiment AI generation, conversation replay, and persistence.
     /// </summary>
     public class AiDatasetResponseGenerator : AstraLabAppServiceBase, IAiDatasetResponseGenerator, ITransientDependency
     {
@@ -27,12 +28,14 @@ namespace AstraLab.Services.AI
         };
 
         private readonly IAiDatasetContextBuilder _aiDatasetContextBuilder;
+        private readonly IAiMlExperimentContextBuilder _aiMlExperimentContextBuilder;
         private readonly IAiDatasetInsightReader _aiDatasetInsightReader;
         private readonly IAiPromptBuilder _aiPromptBuilder;
         private readonly IAiConversationHistoryBuilder _aiConversationHistoryBuilder;
         private readonly IAiTextGenerationClient _aiTextGenerationClient;
         private readonly IRepository<AIConversation, long> _aiConversationRepository;
         private readonly IRepository<AIResponse, long> _aiResponseRepository;
+        private readonly IRepository<MLExperiment, long> _mlExperimentRepository;
         private readonly IDatasetOwnershipAccessChecker _datasetOwnershipAccessChecker;
 
         /// <summary>
@@ -40,26 +43,30 @@ namespace AstraLab.Services.AI
         /// </summary>
         public AiDatasetResponseGenerator(
             IAiDatasetContextBuilder aiDatasetContextBuilder,
+            IAiMlExperimentContextBuilder aiMlExperimentContextBuilder,
             IAiDatasetInsightReader aiDatasetInsightReader,
             IAiPromptBuilder aiPromptBuilder,
             IAiConversationHistoryBuilder aiConversationHistoryBuilder,
             IAiTextGenerationClient aiTextGenerationClient,
             IRepository<AIConversation, long> aiConversationRepository,
             IRepository<AIResponse, long> aiResponseRepository,
+            IRepository<MLExperiment, long> mlExperimentRepository,
             IDatasetOwnershipAccessChecker datasetOwnershipAccessChecker)
         {
             _aiDatasetContextBuilder = aiDatasetContextBuilder;
+            _aiMlExperimentContextBuilder = aiMlExperimentContextBuilder;
             _aiDatasetInsightReader = aiDatasetInsightReader;
             _aiPromptBuilder = aiPromptBuilder;
             _aiConversationHistoryBuilder = aiConversationHistoryBuilder;
             _aiTextGenerationClient = aiTextGenerationClient;
             _aiConversationRepository = aiConversationRepository;
             _aiResponseRepository = aiResponseRepository;
+            _mlExperimentRepository = mlExperimentRepository;
             _datasetOwnershipAccessChecker = datasetOwnershipAccessChecker;
         }
 
         /// <summary>
-        /// Generates and persists a dataset-scoped AI response.
+        /// Generates and persists a dataset-scoped or experiment-scoped AI response.
         /// </summary>
         public async Task<GenerateDatasetAiResponseResult> GenerateAsync(
             AIResponseType responseType,
@@ -67,14 +74,21 @@ namespace AstraLab.Services.AI
             int tenantId,
             long ownerUserId,
             string userQuery = null,
-            long? conversationId = null)
+            long? conversationId = null,
+            long? mlExperimentId = null)
         {
             ValidateRequest(responseType, userQuery);
 
             var datasetVersion = await _datasetOwnershipAccessChecker.GetDatasetVersionForOwnerAsync(datasetVersionId, tenantId, ownerUserId);
+            var mlExperiment = mlExperimentId.HasValue
+                ? await GetValidatedExperimentAsync(mlExperimentId.Value, datasetVersionId, tenantId, ownerUserId)
+                : null;
             var datasetContext = await _aiDatasetContextBuilder.BuildAsync(datasetVersionId, tenantId, ownerUserId);
             var enrichmentContext = ShouldIncludeEnrichment(responseType)
                 ? await _aiDatasetInsightReader.ReadAsync(datasetVersionId, tenantId, ownerUserId)
+                : null;
+            var mlExperimentContext = mlExperimentId.HasValue
+                ? await _aiMlExperimentContextBuilder.BuildAsync(mlExperimentId.Value, tenantId, ownerUserId)
                 : null;
 
             var conversation = conversationId.HasValue
@@ -82,7 +96,7 @@ namespace AstraLab.Services.AI
                 : null;
             var priorResponses = conversation == null
                 ? new List<AIResponse>()
-                : await GetValidatedConversationResponsesAsync(conversation.Id, datasetVersionId);
+                : await GetValidatedConversationResponsesAsync(conversation.Id, datasetVersionId, mlExperimentId);
             var conversationHistory = _aiConversationHistoryBuilder.Build(priorResponses);
 
             var prompt = _aiPromptBuilder.Build(new AiPromptBuildRequest
@@ -90,8 +104,10 @@ namespace AstraLab.Services.AI
                 ResponseType = responseType,
                 DatasetContext = datasetContext,
                 EnrichmentContext = enrichmentContext,
+                MlExperimentContext = mlExperimentContext,
                 UserQuestion = userQuery,
-                IsAutomaticProfilingInsight = false
+                IsAutomaticProfilingInsight = false,
+                IsAutomaticExperimentInsight = false
             });
 
             var generatedText = await _aiTextGenerationClient.GenerateTextAsync(new AiTextGenerationRequest
@@ -122,13 +138,16 @@ namespace AstraLab.Services.AI
                 UserQuery = string.IsNullOrWhiteSpace(userQuery) ? null : userQuery.Trim(),
                 ResponseContent = generatedText.Text.Trim(),
                 ResponseType = responseType,
+                MLExperimentId = mlExperiment?.Id,
                 MetadataJson = BuildMetadataJson(
                     generatedText,
                     datasetContext,
                     enrichmentContext,
+                    mlExperimentContext,
                     conversationHistory.Count,
                     null,
-                    null)
+                    null,
+                    mlExperiment?.Id)
             });
 
             persistedConversation.LastInteractionTime = DateTime.UtcNow;
@@ -193,9 +212,82 @@ namespace AstraLab.Services.AI
                     generatedText,
                     datasetContext,
                     enrichmentContext,
+                    null,
                     0,
                     AiAutomaticInsightMetadata.ProfilingCompletedGenerationTrigger,
-                    datasetProfileId)
+                    datasetProfileId,
+                    null)
+            });
+
+            conversation.LastInteractionTime = DateTime.UtcNow;
+            await CurrentUnitOfWork.SaveChangesAsync();
+
+            return new GenerateDatasetAiResponseResult
+            {
+                ConversationId = conversation.Id,
+                Response = ObjectMapper.Map<AIResponseDto>(response)
+            };
+        }
+
+        /// <summary>
+        /// Generates and persists an experiment-completed automatic insight for the selected machine learning experiment.
+        /// </summary>
+        public async Task<GenerateDatasetAiResponseResult> GenerateAutomaticExperimentInsightAsync(
+            long mlExperimentId,
+            int tenantId,
+            long ownerUserId)
+        {
+            var mlExperiment = await GetValidatedExperimentAsync(mlExperimentId, null, tenantId, ownerUserId);
+            var datasetContext = await _aiDatasetContextBuilder.BuildAsync(mlExperiment.DatasetVersionId, tenantId, ownerUserId);
+            var enrichmentContext = await _aiDatasetInsightReader.ReadAsync(mlExperiment.DatasetVersionId, tenantId, ownerUserId);
+            var mlExperimentContext = await _aiMlExperimentContextBuilder.BuildAsync(mlExperimentId, tenantId, ownerUserId);
+            var prompt = _aiPromptBuilder.Build(new AiPromptBuildRequest
+            {
+                ResponseType = AIResponseType.Insight,
+                DatasetContext = datasetContext,
+                EnrichmentContext = enrichmentContext,
+                MlExperimentContext = mlExperimentContext,
+                IsAutomaticExperimentInsight = true
+            });
+
+            var generatedText = await _aiTextGenerationClient.GenerateTextAsync(new AiTextGenerationRequest
+            {
+                SystemInstructions = prompt.SystemInstructions,
+                ConversationHistory = new List<AiConversationHistoryMessage>(),
+                UserMessage = prompt.UserMessage
+            });
+
+            if (string.IsNullOrWhiteSpace(generatedText.Text))
+            {
+                throw new UserFriendlyException("The AI provider did not return usable response text.");
+            }
+
+            var conversation = await _aiConversationRepository.InsertAsync(new AIConversation
+            {
+                TenantId = tenantId,
+                DatasetId = mlExperiment.DatasetVersion.DatasetId,
+                OwnerUserId = ownerUserId,
+                LastInteractionTime = DateTime.UtcNow
+            });
+
+            var response = await _aiResponseRepository.InsertAsync(new AIResponse
+            {
+                TenantId = tenantId,
+                AIConversation = conversation,
+                DatasetVersionId = mlExperiment.DatasetVersionId,
+                UserQuery = null,
+                ResponseContent = generatedText.Text.Trim(),
+                ResponseType = AIResponseType.Insight,
+                MLExperimentId = mlExperimentId,
+                MetadataJson = BuildMetadataJson(
+                    generatedText,
+                    datasetContext,
+                    enrichmentContext,
+                    mlExperimentContext,
+                    0,
+                    AiAutomaticInsightMetadata.ExperimentCompletedGenerationTrigger,
+                    null,
+                    mlExperimentId)
             });
 
             conversation.LastInteractionTime = DateTime.UtcNow;
@@ -245,9 +337,12 @@ namespace AstraLab.Services.AI
         }
 
         /// <summary>
-        /// Loads prior responses and prevents version-mismatched conversation reuse.
+        /// Loads prior responses and prevents version-mismatched or experiment-mismatched conversation reuse.
         /// </summary>
-        private async Task<List<AIResponse>> GetValidatedConversationResponsesAsync(long conversationId, long datasetVersionId)
+        private async Task<List<AIResponse>> GetValidatedConversationResponsesAsync(
+            long conversationId,
+            long datasetVersionId,
+            long? mlExperimentId)
         {
             var allResponses = await _aiResponseRepository.GetAll()
                 .Where(item => item.AIConversationId == conversationId)
@@ -260,9 +355,48 @@ namespace AstraLab.Services.AI
                 throw new UserFriendlyException("The selected AI conversation belongs to a different dataset version and cannot be reused for this Q&A request.");
             }
 
+            if (allResponses.Any(item => item.MLExperimentId != mlExperimentId))
+            {
+                throw new UserFriendlyException(mlExperimentId.HasValue
+                    ? "The selected AI conversation belongs to a different machine learning experiment and cannot be reused for this request."
+                    : "The selected AI conversation belongs to a machine learning experiment and cannot be reused for a dataset-only request.");
+            }
+
             return allResponses.Count <= AiDatasetGenerationDefaults.MaxConversationResponses
                 ? allResponses
                 : allResponses.Skip(allResponses.Count - AiDatasetGenerationDefaults.MaxConversationResponses).ToList();
+        }
+
+        /// <summary>
+        /// Gets a tenant-owned machine learning experiment and validates dataset-version scope when supplied.
+        /// </summary>
+        private async Task<MLExperiment> GetValidatedExperimentAsync(
+            long mlExperimentId,
+            long? expectedDatasetVersionId,
+            int tenantId,
+            long ownerUserId)
+        {
+            var mlExperiment = await _mlExperimentRepository.GetAll()
+                .Include(item => item.DatasetVersion)
+                    .ThenInclude(item => item.Dataset)
+                .Where(item =>
+                    item.Id == mlExperimentId &&
+                    item.TenantId == tenantId &&
+                    item.DatasetVersion.TenantId == tenantId &&
+                    item.DatasetVersion.Dataset.OwnerUserId == ownerUserId)
+                .SingleOrDefaultAsync();
+
+            if (mlExperiment == null)
+            {
+                throw new UserFriendlyException("The requested ML experiment could not be found.");
+            }
+
+            if (expectedDatasetVersionId.HasValue && mlExperiment.DatasetVersionId != expectedDatasetVersionId.Value)
+            {
+                throw new UserFriendlyException("The selected ML experiment does not belong to the requested dataset version.");
+            }
+
+            return mlExperiment;
         }
 
         /// <summary>
@@ -280,14 +414,17 @@ namespace AstraLab.Services.AI
             AiTextGenerationResult result,
             AiDatasetContext datasetContext,
             AiDatasetInsightContext enrichmentContext,
+            AiMlExperimentContext mlExperimentContext,
             int replayedMessageCount,
             string generationTrigger,
-            long? datasetProfileId)
+            long? datasetProfileId,
+            long? mlExperimentId)
         {
             return JsonSerializer.Serialize(new
             {
                 generationTrigger,
                 datasetProfileId,
+                mlExperimentId,
                 provider = result.Provider,
                 model = result.Model,
                 providerResponseId = result.ProviderResponseId,
@@ -299,7 +436,10 @@ namespace AstraLab.Services.AI
                     wasColumnContextPruned = datasetContext.IsColumnContextPruned,
                     enrichedHighSignalColumns = enrichmentContext?.HighSignalColumns?.Count ?? 0,
                     enrichedTransformations = enrichmentContext?.RecentTransformations?.Count ?? 0,
-                    replayedConversationMessages = replayedMessageCount
+                    replayedConversationMessages = replayedMessageCount,
+                    experimentMetrics = mlExperimentContext?.Metrics?.Count ?? 0,
+                    experimentFeatureImportances = mlExperimentContext?.FeatureImportances?.Count ?? 0,
+                    experimentWarnings = mlExperimentContext?.Warnings?.Count ?? 0
                 }
             }, MetadataSerializerOptions);
         }

--- a/aspnet-core/src/AstraLab.Application/Services/AI/AiDatasetResponseGenerator.cs
+++ b/aspnet-core/src/AstraLab.Application/Services/AI/AiDatasetResponseGenerator.cs
@@ -1,0 +1,229 @@
+using System.Collections.Generic;
+using System;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+using Abp.Dependency;
+using Abp.Domain.Repositories;
+using Abp.UI;
+using AstraLab.Core.Domains.AI;
+using AstraLab.Core.Domains.Datasets;
+using AstraLab.Services.AI.Dto;
+using AstraLab.Services.Datasets;
+using Microsoft.EntityFrameworkCore;
+
+namespace AstraLab.Services.AI
+{
+    /// <summary>
+    /// Orchestrates grounded dataset AI generation, conversation replay, and persistence.
+    /// </summary>
+    public class AiDatasetResponseGenerator : AstraLabAppServiceBase, IAiDatasetResponseGenerator, ITransientDependency
+    {
+        private static readonly JsonSerializerOptions MetadataSerializerOptions = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+        };
+
+        private readonly IAiDatasetContextBuilder _aiDatasetContextBuilder;
+        private readonly IAiDatasetInsightReader _aiDatasetInsightReader;
+        private readonly IAiPromptBuilder _aiPromptBuilder;
+        private readonly IAiConversationHistoryBuilder _aiConversationHistoryBuilder;
+        private readonly IAiTextGenerationClient _aiTextGenerationClient;
+        private readonly IRepository<AIConversation, long> _aiConversationRepository;
+        private readonly IRepository<AIResponse, long> _aiResponseRepository;
+        private readonly IDatasetOwnershipAccessChecker _datasetOwnershipAccessChecker;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AiDatasetResponseGenerator"/> class.
+        /// </summary>
+        public AiDatasetResponseGenerator(
+            IAiDatasetContextBuilder aiDatasetContextBuilder,
+            IAiDatasetInsightReader aiDatasetInsightReader,
+            IAiPromptBuilder aiPromptBuilder,
+            IAiConversationHistoryBuilder aiConversationHistoryBuilder,
+            IAiTextGenerationClient aiTextGenerationClient,
+            IRepository<AIConversation, long> aiConversationRepository,
+            IRepository<AIResponse, long> aiResponseRepository,
+            IDatasetOwnershipAccessChecker datasetOwnershipAccessChecker)
+        {
+            _aiDatasetContextBuilder = aiDatasetContextBuilder;
+            _aiDatasetInsightReader = aiDatasetInsightReader;
+            _aiPromptBuilder = aiPromptBuilder;
+            _aiConversationHistoryBuilder = aiConversationHistoryBuilder;
+            _aiTextGenerationClient = aiTextGenerationClient;
+            _aiConversationRepository = aiConversationRepository;
+            _aiResponseRepository = aiResponseRepository;
+            _datasetOwnershipAccessChecker = datasetOwnershipAccessChecker;
+        }
+
+        /// <summary>
+        /// Generates and persists a dataset-scoped AI response.
+        /// </summary>
+        public async Task<GenerateDatasetAiResponseResult> GenerateAsync(
+            AIResponseType responseType,
+            long datasetVersionId,
+            int tenantId,
+            long ownerUserId,
+            string userQuery = null,
+            long? conversationId = null)
+        {
+            ValidateRequest(responseType, userQuery);
+
+            var datasetVersion = await _datasetOwnershipAccessChecker.GetDatasetVersionForOwnerAsync(datasetVersionId, tenantId, ownerUserId);
+            var datasetContext = await _aiDatasetContextBuilder.BuildAsync(datasetVersionId, tenantId, ownerUserId);
+            var enrichmentContext = ShouldIncludeEnrichment(responseType)
+                ? await _aiDatasetInsightReader.ReadAsync(datasetVersionId, tenantId, ownerUserId)
+                : null;
+
+            var conversation = conversationId.HasValue
+                ? await GetValidatedConversationAsync(conversationId.Value, datasetVersion, tenantId, ownerUserId)
+                : null;
+            var priorResponses = conversation == null
+                ? new List<AIResponse>()
+                : await GetValidatedConversationResponsesAsync(conversation.Id, datasetVersionId);
+            var conversationHistory = _aiConversationHistoryBuilder.Build(priorResponses);
+
+            var prompt = _aiPromptBuilder.Build(new AiPromptBuildRequest
+            {
+                ResponseType = responseType,
+                DatasetContext = datasetContext,
+                EnrichmentContext = enrichmentContext,
+                UserQuestion = userQuery
+            });
+
+            var generatedText = await _aiTextGenerationClient.GenerateTextAsync(new AiTextGenerationRequest
+            {
+                SystemInstructions = prompt.SystemInstructions,
+                ConversationHistory = conversationHistory,
+                UserMessage = prompt.UserMessage
+            });
+
+            if (string.IsNullOrWhiteSpace(generatedText.Text))
+            {
+                throw new UserFriendlyException("The AI provider did not return usable response text.");
+            }
+
+            var persistedConversation = conversation ?? await _aiConversationRepository.InsertAsync(new AIConversation
+            {
+                TenantId = tenantId,
+                DatasetId = datasetVersion.DatasetId,
+                OwnerUserId = ownerUserId,
+                LastInteractionTime = DateTime.UtcNow
+            });
+
+            var response = await _aiResponseRepository.InsertAsync(new AIResponse
+            {
+                TenantId = tenantId,
+                AIConversation = persistedConversation,
+                DatasetVersionId = datasetVersionId,
+                UserQuery = string.IsNullOrWhiteSpace(userQuery) ? null : userQuery.Trim(),
+                ResponseContent = generatedText.Text.Trim(),
+                ResponseType = responseType,
+                MetadataJson = BuildMetadataJson(generatedText, datasetContext, enrichmentContext, conversationHistory.Count)
+            });
+
+            persistedConversation.LastInteractionTime = DateTime.UtcNow;
+            await CurrentUnitOfWork.SaveChangesAsync();
+
+            return new GenerateDatasetAiResponseResult
+            {
+                ConversationId = persistedConversation.Id,
+                Response = ObjectMapper.Map<AIResponseDto>(response)
+            };
+        }
+
+        /// <summary>
+        /// Validates the incoming request shape for the selected task.
+        /// </summary>
+        private static void ValidateRequest(AIResponseType responseType, string userQuery)
+        {
+            if (responseType == AIResponseType.QuestionAnswer && string.IsNullOrWhiteSpace(userQuery))
+            {
+                throw new UserFriendlyException("A question is required for dataset AI Q&A.");
+            }
+        }
+
+        /// <summary>
+        /// Gets the existing conversation after validating tenant, owner, and dataset scope.
+        /// </summary>
+        private async Task<AIConversation> GetValidatedConversationAsync(
+            long conversationId,
+            DatasetVersion datasetVersion,
+            int tenantId,
+            long ownerUserId)
+        {
+            var conversation = await _aiConversationRepository.GetAll()
+                .Where(item =>
+                    item.Id == conversationId &&
+                    item.TenantId == tenantId &&
+                    item.OwnerUserId == ownerUserId &&
+                    item.DatasetId == datasetVersion.DatasetId)
+                .SingleOrDefaultAsync();
+
+            if (conversation == null)
+            {
+                throw new UserFriendlyException("The requested AI conversation could not be found for the selected dataset.");
+            }
+
+            return conversation;
+        }
+
+        /// <summary>
+        /// Loads prior responses and prevents version-mismatched conversation reuse.
+        /// </summary>
+        private async Task<List<AIResponse>> GetValidatedConversationResponsesAsync(long conversationId, long datasetVersionId)
+        {
+            var allResponses = await _aiResponseRepository.GetAll()
+                .Where(item => item.AIConversationId == conversationId)
+                .OrderBy(item => item.CreationTime)
+                .ThenBy(item => item.Id)
+                .ToListAsync();
+
+            if (allResponses.Any(item => item.DatasetVersionId != datasetVersionId))
+            {
+                throw new UserFriendlyException("The selected AI conversation belongs to a different dataset version and cannot be reused for this Q&A request.");
+            }
+
+            return allResponses.Count <= AiDatasetGenerationDefaults.MaxConversationResponses
+                ? allResponses
+                : allResponses.Skip(allResponses.Count - AiDatasetGenerationDefaults.MaxConversationResponses).ToList();
+        }
+
+        /// <summary>
+        /// Determines whether extra enrichment should be loaded for the selected task.
+        /// </summary>
+        private static bool ShouldIncludeEnrichment(AIResponseType responseType)
+        {
+            return responseType == AIResponseType.Recommendation || responseType == AIResponseType.QuestionAnswer;
+        }
+
+        /// <summary>
+        /// Builds the compact persisted metadata payload for a successful provider call.
+        /// </summary>
+        private static string BuildMetadataJson(
+            AiTextGenerationResult result,
+            AiDatasetContext datasetContext,
+            AiDatasetInsightContext enrichmentContext,
+            int replayedMessageCount)
+        {
+            return JsonSerializer.Serialize(new
+            {
+                provider = result.Provider,
+                model = result.Model,
+                providerResponseId = result.ProviderResponseId,
+                usageJson = result.UsageJson,
+                context = new
+                {
+                    totalColumns = datasetContext.Columns.Count,
+                    detailedColumns = datasetContext.DetailedColumnCount,
+                    wasColumnContextPruned = datasetContext.IsColumnContextPruned,
+                    enrichedHighSignalColumns = enrichmentContext?.HighSignalColumns?.Count ?? 0,
+                    enrichedTransformations = enrichmentContext?.RecentTransformations?.Count ?? 0,
+                    replayedConversationMessages = replayedMessageCount
+                }
+            }, MetadataSerializerOptions);
+        }
+    }
+}

--- a/aspnet-core/src/AstraLab.Application/Services/AI/AiDatasetSummaryContext.cs
+++ b/aspnet-core/src/AstraLab.Application/Services/AI/AiDatasetSummaryContext.cs
@@ -1,0 +1,61 @@
+using System;
+using AstraLab.Core.Domains.Datasets;
+
+namespace AstraLab.Services.AI
+{
+    /// <summary>
+    /// Represents the dataset-level summary included in AI context assembly.
+    /// </summary>
+    public class AiDatasetSummaryContext
+    {
+        /// <summary>
+        /// Gets or sets the dataset identifier.
+        /// </summary>
+        public long DatasetId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the dataset display name.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the compact dataset description.
+        /// </summary>
+        public string Description { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the dataset description was truncated.
+        /// </summary>
+        public bool DescriptionWasTruncated { get; set; }
+
+        /// <summary>
+        /// Gets or sets the source dataset format.
+        /// </summary>
+        public DatasetFormat SourceFormat { get; set; }
+
+        /// <summary>
+        /// Gets or sets the dataset lifecycle status.
+        /// </summary>
+        public DatasetStatus Status { get; set; }
+
+        /// <summary>
+        /// Gets or sets the owning user identifier.
+        /// </summary>
+        public long OwnerUserId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the compact original file name.
+        /// </summary>
+        public string OriginalFileName { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the original file name was truncated.
+        /// </summary>
+        public bool OriginalFileNameWasTruncated { get; set; }
+
+        /// <summary>
+        /// Gets or sets the dataset creation time.
+        /// </summary>
+        public DateTime CreationTime { get; set; }
+    }
+}

--- a/aspnet-core/src/AstraLab.Application/Services/AI/AiDatasetVersionContext.cs
+++ b/aspnet-core/src/AstraLab.Application/Services/AI/AiDatasetVersionContext.cs
@@ -1,0 +1,61 @@
+using System;
+using AstraLab.Core.Domains.Datasets;
+
+namespace AstraLab.Services.AI
+{
+    /// <summary>
+    /// Represents the selected dataset version summary included in AI context assembly.
+    /// </summary>
+    public class AiDatasetVersionContext
+    {
+        /// <summary>
+        /// Gets or sets the dataset version identifier.
+        /// </summary>
+        public long DatasetVersionId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the parent dataset identifier.
+        /// </summary>
+        public long DatasetId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the sequential version number.
+        /// </summary>
+        public int VersionNumber { get; set; }
+
+        /// <summary>
+        /// Gets or sets the dataset version type.
+        /// </summary>
+        public DatasetVersionType VersionType { get; set; }
+
+        /// <summary>
+        /// Gets or sets the dataset version status.
+        /// </summary>
+        public DatasetVersionStatus Status { get; set; }
+
+        /// <summary>
+        /// Gets or sets the parent version identifier when present.
+        /// </summary>
+        public long? ParentVersionId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the persisted row count when known.
+        /// </summary>
+        public int? RowCount { get; set; }
+
+        /// <summary>
+        /// Gets or sets the persisted column count when known.
+        /// </summary>
+        public int? ColumnCount { get; set; }
+
+        /// <summary>
+        /// Gets or sets the stored dataset size in bytes.
+        /// </summary>
+        public long SizeBytes { get; set; }
+
+        /// <summary>
+        /// Gets or sets the dataset version creation time.
+        /// </summary>
+        public DateTime CreationTime { get; set; }
+    }
+}

--- a/aspnet-core/src/AstraLab.Application/Services/AI/AiInsightColumnContext.cs
+++ b/aspnet-core/src/AstraLab.Application/Services/AI/AiInsightColumnContext.cs
@@ -1,0 +1,68 @@
+namespace AstraLab.Services.AI
+{
+    /// <summary>
+    /// Represents a compact high-signal profiled column insight.
+    /// </summary>
+    public class AiInsightColumnContext
+    {
+        /// <summary>
+        /// Gets or sets the dataset column identifier.
+        /// </summary>
+        public long DatasetColumnId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the column name.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the inferred data type.
+        /// </summary>
+        public string DataType { get; set; }
+
+        /// <summary>
+        /// Gets or sets the null count.
+        /// </summary>
+        public long NullCount { get; set; }
+
+        /// <summary>
+        /// Gets or sets the null percentage.
+        /// </summary>
+        public decimal NullPercentage { get; set; }
+
+        /// <summary>
+        /// Gets or sets the distinct value count.
+        /// </summary>
+        public long? DistinctCount { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether the column contains anomalies.
+        /// </summary>
+        public bool HasAnomalies { get; set; }
+
+        /// <summary>
+        /// Gets or sets the anomaly count.
+        /// </summary>
+        public long AnomalyCount { get; set; }
+
+        /// <summary>
+        /// Gets or sets the anomaly percentage.
+        /// </summary>
+        public decimal AnomalyPercentage { get; set; }
+
+        /// <summary>
+        /// Gets or sets the mean when available.
+        /// </summary>
+        public decimal? Mean { get; set; }
+
+        /// <summary>
+        /// Gets or sets the minimum when available.
+        /// </summary>
+        public decimal? Min { get; set; }
+
+        /// <summary>
+        /// Gets or sets the maximum when available.
+        /// </summary>
+        public decimal? Max { get; set; }
+    }
+}

--- a/aspnet-core/src/AstraLab.Application/Services/AI/AiMlExperimentContext.cs
+++ b/aspnet-core/src/AstraLab.Application/Services/AI/AiMlExperimentContext.cs
@@ -1,0 +1,81 @@
+using System.Collections.Generic;
+using AstraLab.Core.Domains.ML;
+
+namespace AstraLab.Services.AI
+{
+    /// <summary>
+    /// Represents the structured machine learning experiment context assembled for AI workflows.
+    /// </summary>
+    public class AiMlExperimentContext
+    {
+        /// <summary>
+        /// Gets or sets the machine learning experiment identifier.
+        /// </summary>
+        public long MLExperimentId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the dataset version identifier that the experiment ran against.
+        /// </summary>
+        public long DatasetVersionId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the current experiment status.
+        /// </summary>
+        public MLExperimentStatus Status { get; set; }
+
+        /// <summary>
+        /// Gets or sets the machine learning task type.
+        /// </summary>
+        public MLTaskType TaskType { get; set; }
+
+        /// <summary>
+        /// Gets or sets the selected algorithm key.
+        /// </summary>
+        public string AlgorithmKey { get; set; }
+
+        /// <summary>
+        /// Gets or sets the optional target column name.
+        /// </summary>
+        public string TargetColumnName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the selected feature names.
+        /// </summary>
+        public IReadOnlyList<string> FeatureNames { get; set; }
+
+        /// <summary>
+        /// Gets or sets the compact training configuration JSON.
+        /// </summary>
+        public string TrainingConfigurationJson { get; set; }
+
+        /// <summary>
+        /// Gets or sets the warnings surfaced by the experiment or model.
+        /// </summary>
+        public IReadOnlyList<string> Warnings { get; set; }
+
+        /// <summary>
+        /// Gets or sets the structured metric summary rows.
+        /// </summary>
+        public IReadOnlyList<AiMlMetricContext> Metrics { get; set; }
+
+        /// <summary>
+        /// Gets or sets the structured feature-importance rows.
+        /// </summary>
+        public IReadOnlyList<AiMlFeatureImportanceContext> FeatureImportances { get; set; }
+
+        /// <summary>
+        /// Gets or sets the compact performance summary JSON returned by the model.
+        /// </summary>
+        public string PerformanceSummaryJson { get; set; }
+
+        /// <summary>
+        /// Gets or sets the model type returned by the executor.
+        /// </summary>
+        public string ModelType { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether model output is available.
+        /// </summary>
+        public bool HasModelOutput { get; set; }
+    }
+}

--- a/aspnet-core/src/AstraLab.Application/Services/AI/AiMlExperimentContextBuilder.cs
+++ b/aspnet-core/src/AstraLab.Application/Services/AI/AiMlExperimentContextBuilder.cs
@@ -1,0 +1,153 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Abp.Dependency;
+using Abp.Domain.Repositories;
+using Abp.UI;
+using AstraLab.Core.Domains.ML;
+using AstraLab.Services.Datasets;
+using Microsoft.EntityFrameworkCore;
+
+namespace AstraLab.Services.AI
+{
+    /// <summary>
+    /// Builds a structured machine learning experiment context from persisted experiment metadata and model results.
+    /// </summary>
+    public class AiMlExperimentContextBuilder : AstraLabAppServiceBase, IAiMlExperimentContextBuilder, ITransientDependency
+    {
+        private readonly IRepository<MLExperiment, long> _mlExperimentRepository;
+        private readonly IDatasetOwnershipAccessChecker _datasetOwnershipAccessChecker;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AiMlExperimentContextBuilder"/> class.
+        /// </summary>
+        public AiMlExperimentContextBuilder(
+            IRepository<MLExperiment, long> mlExperimentRepository,
+            IDatasetOwnershipAccessChecker datasetOwnershipAccessChecker)
+        {
+            _mlExperimentRepository = mlExperimentRepository;
+            _datasetOwnershipAccessChecker = datasetOwnershipAccessChecker;
+        }
+
+        /// <summary>
+        /// Builds structured machine learning experiment context for the specified owner-scoped experiment.
+        /// </summary>
+        public async Task<AiMlExperimentContext> BuildAsync(long mlExperimentId, int tenantId, long ownerUserId)
+        {
+            var experiment = await _mlExperimentRepository.GetAll()
+                .Include(item => item.TargetDatasetColumn)
+                .Include(item => item.SelectedFeatures)
+                    .ThenInclude(item => item.DatasetColumn)
+                .Include(item => item.Model)
+                    .ThenInclude(item => item.Metrics)
+                .Include(item => item.Model)
+                    .ThenInclude(item => item.FeatureImportances)
+                        .ThenInclude(item => item.DatasetColumn)
+                .Where(item =>
+                    item.Id == mlExperimentId &&
+                    item.TenantId == tenantId &&
+                    item.DatasetVersion.TenantId == tenantId &&
+                    item.DatasetVersion.Dataset.OwnerUserId == ownerUserId)
+                .SingleOrDefaultAsync();
+
+            if (experiment == null)
+            {
+                throw new UserFriendlyException("The requested ML experiment could not be found.");
+            }
+
+            await _datasetOwnershipAccessChecker.GetDatasetVersionForOwnerAsync(experiment.DatasetVersionId, tenantId, ownerUserId);
+
+            return new AiMlExperimentContext
+            {
+                MLExperimentId = experiment.Id,
+                DatasetVersionId = experiment.DatasetVersionId,
+                Status = experiment.Status,
+                TaskType = experiment.TaskType,
+                AlgorithmKey = experiment.AlgorithmKey,
+                TargetColumnName = experiment.TargetDatasetColumn?.Name,
+                FeatureNames = experiment.SelectedFeatures
+                    .OrderBy(item => item.Ordinal)
+                    .Select(item => item.DatasetColumn?.Name ?? ("Column " + item.DatasetColumnId))
+                    .ToList(),
+                TrainingConfigurationJson = NormalizeJson(experiment.TrainingConfigurationJson),
+                Warnings = ReadWarnings(experiment),
+                Metrics = experiment.Model?.Metrics
+                    .OrderBy(item => item.MetricName)
+                    .Select(item => new AiMlMetricContext
+                    {
+                        MetricName = item.MetricName,
+                        MetricValue = item.MetricValue
+                    })
+                    .ToList() ?? new List<AiMlMetricContext>(),
+                FeatureImportances = experiment.Model?.FeatureImportances
+                    .OrderBy(item => item.Rank)
+                    .Select(item => new AiMlFeatureImportanceContext
+                    {
+                        DatasetColumnId = item.DatasetColumnId,
+                        ColumnName = item.DatasetColumn?.Name,
+                        ImportanceScore = item.ImportanceScore,
+                        Rank = item.Rank
+                    })
+                    .ToList() ?? new List<AiMlFeatureImportanceContext>(),
+                PerformanceSummaryJson = NormalizeJson(experiment.Model?.PerformanceSummaryJson),
+                ModelType = experiment.Model?.ModelType,
+                HasModelOutput = experiment.Model != null
+            };
+        }
+
+        /// <summary>
+        /// Reads experiment and model warnings into one distinct collection.
+        /// </summary>
+        private static IReadOnlyList<string> ReadWarnings(MLExperiment experiment)
+        {
+            return ReadWarningArray(experiment.WarningsJson)
+                .Concat(ReadWarningArray(experiment.Model?.WarningsJson))
+                .Distinct()
+                .ToList();
+        }
+
+        /// <summary>
+        /// Reads a serialized warning array when one is present and valid.
+        /// </summary>
+        private static IReadOnlyList<string> ReadWarningArray(string warningsJson)
+        {
+            if (string.IsNullOrWhiteSpace(warningsJson))
+            {
+                return new List<string>();
+            }
+
+            try
+            {
+                return JsonSerializer.Deserialize<List<string>>(warningsJson) ?? new List<string>();
+            }
+            catch (JsonException)
+            {
+                return new List<string>();
+            }
+        }
+
+        /// <summary>
+        /// Normalizes long JSON blobs to compact payloads so they stay predictable in prompt context.
+        /// </summary>
+        private static string NormalizeJson(string json)
+        {
+            if (string.IsNullOrWhiteSpace(json))
+            {
+                return null;
+            }
+
+            try
+            {
+                using (var document = JsonDocument.Parse(json))
+                {
+                    return JsonSerializer.Serialize(document.RootElement);
+                }
+            }
+            catch (JsonException)
+            {
+                return json.Trim();
+            }
+        }
+    }
+}

--- a/aspnet-core/src/AstraLab.Application/Services/AI/AiMlFeatureImportanceContext.cs
+++ b/aspnet-core/src/AstraLab.Application/Services/AI/AiMlFeatureImportanceContext.cs
@@ -1,0 +1,28 @@
+namespace AstraLab.Services.AI
+{
+    /// <summary>
+    /// Represents one persisted machine learning feature-importance row included in AI experiment context.
+    /// </summary>
+    public class AiMlFeatureImportanceContext
+    {
+        /// <summary>
+        /// Gets or sets the dataset column identifier.
+        /// </summary>
+        public long DatasetColumnId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the optional column name.
+        /// </summary>
+        public string ColumnName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the importance score.
+        /// </summary>
+        public decimal ImportanceScore { get; set; }
+
+        /// <summary>
+        /// Gets or sets the persisted rank.
+        /// </summary>
+        public int Rank { get; set; }
+    }
+}

--- a/aspnet-core/src/AstraLab.Application/Services/AI/AiMlMetricContext.cs
+++ b/aspnet-core/src/AstraLab.Application/Services/AI/AiMlMetricContext.cs
@@ -1,0 +1,18 @@
+namespace AstraLab.Services.AI
+{
+    /// <summary>
+    /// Represents one persisted machine learning metric included in AI experiment context.
+    /// </summary>
+    public class AiMlMetricContext
+    {
+        /// <summary>
+        /// Gets or sets the metric name.
+        /// </summary>
+        public string MetricName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the metric value.
+        /// </summary>
+        public decimal MetricValue { get; set; }
+    }
+}

--- a/aspnet-core/src/AstraLab.Application/Services/AI/AiProfilingContext.cs
+++ b/aspnet-core/src/AstraLab.Application/Services/AI/AiProfilingContext.cs
@@ -1,0 +1,55 @@
+using System;
+
+namespace AstraLab.Services.AI
+{
+    /// <summary>
+    /// Represents the dataset-level profiling summary included in AI context assembly.
+    /// </summary>
+    public class AiProfilingContext
+    {
+        /// <summary>
+        /// Gets or sets the persisted profile identifier.
+        /// </summary>
+        public long ProfileId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the total profiled row count.
+        /// </summary>
+        public long RowCount { get; set; }
+
+        /// <summary>
+        /// Gets or sets the duplicate row count.
+        /// </summary>
+        public long DuplicateRowCount { get; set; }
+
+        /// <summary>
+        /// Gets or sets the computed data health score.
+        /// </summary>
+        public decimal DataHealthScore { get; set; }
+
+        /// <summary>
+        /// Gets or sets the total null count across the profile.
+        /// </summary>
+        public long TotalNullCount { get; set; }
+
+        /// <summary>
+        /// Gets or sets the overall null percentage across the profile.
+        /// </summary>
+        public decimal OverallNullPercentage { get; set; }
+
+        /// <summary>
+        /// Gets or sets the total anomaly count across the profile.
+        /// </summary>
+        public long TotalAnomalyCount { get; set; }
+
+        /// <summary>
+        /// Gets or sets the overall anomaly percentage across the profile.
+        /// </summary>
+        public decimal OverallAnomalyPercentage { get; set; }
+
+        /// <summary>
+        /// Gets or sets the profile creation time.
+        /// </summary>
+        public DateTime CreationTime { get; set; }
+    }
+}

--- a/aspnet-core/src/AstraLab.Application/Services/AI/AiPromptBuildRequest.cs
+++ b/aspnet-core/src/AstraLab.Application/Services/AI/AiPromptBuildRequest.cs
@@ -13,6 +13,11 @@ namespace AstraLab.Services.AI
         public bool IsAutomaticProfilingInsight { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether this prompt is for an automatic experiment-completed insight.
+        /// </summary>
+        public bool IsAutomaticExperimentInsight { get; set; }
+
+        /// <summary>
         /// Gets or sets the requested AI response type.
         /// </summary>
         public AIResponseType ResponseType { get; set; }
@@ -26,6 +31,11 @@ namespace AstraLab.Services.AI
         /// Gets or sets the optional enrichment context.
         /// </summary>
         public AiDatasetInsightContext EnrichmentContext { get; set; }
+
+        /// <summary>
+        /// Gets or sets the optional machine learning experiment context.
+        /// </summary>
+        public AiMlExperimentContext MlExperimentContext { get; set; }
 
         /// <summary>
         /// Gets or sets the optional natural-language question.

--- a/aspnet-core/src/AstraLab.Application/Services/AI/AiPromptBuildRequest.cs
+++ b/aspnet-core/src/AstraLab.Application/Services/AI/AiPromptBuildRequest.cs
@@ -1,0 +1,30 @@
+using AstraLab.Core.Domains.AI;
+
+namespace AstraLab.Services.AI
+{
+    /// <summary>
+    /// Represents the structured inputs required to build a dataset AI prompt.
+    /// </summary>
+    public class AiPromptBuildRequest
+    {
+        /// <summary>
+        /// Gets or sets the requested AI response type.
+        /// </summary>
+        public AIResponseType ResponseType { get; set; }
+
+        /// <summary>
+        /// Gets or sets the base dataset context.
+        /// </summary>
+        public AiDatasetContext DatasetContext { get; set; }
+
+        /// <summary>
+        /// Gets or sets the optional enrichment context.
+        /// </summary>
+        public AiDatasetInsightContext EnrichmentContext { get; set; }
+
+        /// <summary>
+        /// Gets or sets the optional natural-language question.
+        /// </summary>
+        public string UserQuestion { get; set; }
+    }
+}

--- a/aspnet-core/src/AstraLab.Application/Services/AI/AiPromptBuildRequest.cs
+++ b/aspnet-core/src/AstraLab.Application/Services/AI/AiPromptBuildRequest.cs
@@ -8,6 +8,11 @@ namespace AstraLab.Services.AI
     public class AiPromptBuildRequest
     {
         /// <summary>
+        /// Gets or sets a value indicating whether this prompt is for an automatic profiling-triggered insight.
+        /// </summary>
+        public bool IsAutomaticProfilingInsight { get; set; }
+
+        /// <summary>
         /// Gets or sets the requested AI response type.
         /// </summary>
         public AIResponseType ResponseType { get; set; }

--- a/aspnet-core/src/AstraLab.Application/Services/AI/AiPromptBuildResult.cs
+++ b/aspnet-core/src/AstraLab.Application/Services/AI/AiPromptBuildResult.cs
@@ -1,0 +1,18 @@
+namespace AstraLab.Services.AI
+{
+    /// <summary>
+    /// Represents the generated provider-neutral prompt payload.
+    /// </summary>
+    public class AiPromptBuildResult
+    {
+        /// <summary>
+        /// Gets or sets the system-level instructions.
+        /// </summary>
+        public string SystemInstructions { get; set; }
+
+        /// <summary>
+        /// Gets or sets the final user prompt.
+        /// </summary>
+        public string UserMessage { get; set; }
+    }
+}

--- a/aspnet-core/src/AstraLab.Application/Services/AI/AiPromptBuilder.cs
+++ b/aspnet-core/src/AstraLab.Application/Services/AI/AiPromptBuilder.cs
@@ -29,7 +29,7 @@ namespace AstraLab.Services.AI
         {
             return new AiPromptBuildResult
             {
-                SystemInstructions = BuildSystemInstructions(request.ResponseType),
+                SystemInstructions = BuildSystemInstructions(request.ResponseType, request.IsAutomaticProfilingInsight),
                 UserMessage = BuildUserMessage(request)
             };
         }
@@ -37,8 +37,15 @@ namespace AstraLab.Services.AI
         /// <summary>
         /// Builds the task-specific system prompt.
         /// </summary>
-        private static string BuildSystemInstructions(AIResponseType responseType)
+        private static string BuildSystemInstructions(AIResponseType responseType, bool isAutomaticProfilingInsight)
         {
+            if (isAutomaticProfilingInsight)
+            {
+                return "You are AstraLab's dataset assistant. Use only the provided dataset context and enrichment. " +
+                       "Do not invent raw values, rows, or external facts. Write for a non-technical user in clear, plain language. " +
+                       "Return exactly four short sections titled Summary, Key data quality issues, Notable patterns or anomalies, and Suggested next steps.";
+            }
+
             var taskGuidance = responseType switch
             {
                 AIResponseType.Summary => "Write a concise dataset summary with a short overview and the most important risks.",
@@ -60,7 +67,7 @@ namespace AstraLab.Services.AI
         {
             var builder = new StringBuilder();
             builder.AppendLine("Task:");
-            builder.AppendLine(GetTaskLabel(request.ResponseType));
+            builder.AppendLine(GetTaskLabel(request.ResponseType, request.IsAutomaticProfilingInsight));
             builder.AppendLine();
 
             if (!string.IsNullOrWhiteSpace(request.UserQuestion))
@@ -82,15 +89,20 @@ namespace AstraLab.Services.AI
 
             builder.AppendLine();
             builder.AppendLine("Response rules:");
-            builder.AppendLine(GetResponseRules(request.ResponseType));
+            builder.AppendLine(GetResponseRules(request.ResponseType, request.IsAutomaticProfilingInsight));
             return builder.ToString().Trim();
         }
 
         /// <summary>
         /// Gets the concise task label included in the prompt body.
         /// </summary>
-        private static string GetTaskLabel(AIResponseType responseType)
+        private static string GetTaskLabel(AIResponseType responseType, bool isAutomaticProfilingInsight)
         {
+            if (isAutomaticProfilingInsight)
+            {
+                return "Generate an automatic dataset insight after profiling completed.";
+            }
+
             return responseType switch
             {
                 AIResponseType.Summary => "Generate a dataset summary.",
@@ -104,8 +116,14 @@ namespace AstraLab.Services.AI
         /// <summary>
         /// Gets the task-specific output rules that keep responses concise and useful.
         /// </summary>
-        private static string GetResponseRules(AIResponseType responseType)
+        private static string GetResponseRules(AIResponseType responseType, bool isAutomaticProfilingInsight)
         {
+            if (isAutomaticProfilingInsight)
+            {
+                return "Use exactly these headings in order: Summary, Key data quality issues, Notable patterns or anomalies, Suggested next steps. " +
+                       "Keep each section short, plain-language, and grounded in the provided profiling and schema context only.";
+            }
+
             return responseType switch
             {
                 AIResponseType.Summary => "Use at most two short paragraphs or four bullet points. Mention structure, quality, and one notable risk.",

--- a/aspnet-core/src/AstraLab.Application/Services/AI/AiPromptBuilder.cs
+++ b/aspnet-core/src/AstraLab.Application/Services/AI/AiPromptBuilder.cs
@@ -1,0 +1,119 @@
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Abp.Dependency;
+using AstraLab.Core.Domains.AI;
+
+namespace AstraLab.Services.AI
+{
+    /// <summary>
+    /// Builds concise deterministic prompts for dataset AI workflows.
+    /// </summary>
+    public class AiPromptBuilder : IAiPromptBuilder, ITransientDependency
+    {
+        private static readonly JsonSerializerOptions SerializerOptions = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            WriteIndented = false,
+            Converters =
+            {
+                new JsonStringEnumConverter(JsonNamingPolicy.CamelCase)
+            }
+        };
+
+        /// <summary>
+        /// Builds a prompt payload for the requested dataset AI task.
+        /// </summary>
+        public AiPromptBuildResult Build(AiPromptBuildRequest request)
+        {
+            return new AiPromptBuildResult
+            {
+                SystemInstructions = BuildSystemInstructions(request.ResponseType),
+                UserMessage = BuildUserMessage(request)
+            };
+        }
+
+        /// <summary>
+        /// Builds the task-specific system prompt.
+        /// </summary>
+        private static string BuildSystemInstructions(AIResponseType responseType)
+        {
+            var taskGuidance = responseType switch
+            {
+                AIResponseType.Summary => "Write a concise dataset summary with a short overview and the most important risks.",
+                AIResponseType.Insight => "Identify the most important data-quality and structure insights. Focus on the top findings only.",
+                AIResponseType.Recommendation => "Recommend prioritized cleaning and transformation actions with brief rationale and expected impact.",
+                AIResponseType.QuestionAnswer => "Answer the user's question directly first, then support it with brief evidence from the dataset context.",
+                _ => "Provide a concise and grounded explanation based only on the supplied dataset context."
+            };
+
+            return "You are AstraLab's dataset assistant. Use only the provided dataset context and enrichment. Do not invent raw values, rows, or external facts. " +
+                   "Be concise, practical, and specific. When context is missing, say so clearly. " +
+                   taskGuidance;
+        }
+
+        /// <summary>
+        /// Builds the final user prompt in a deterministic serialized format.
+        /// </summary>
+        private static string BuildUserMessage(AiPromptBuildRequest request)
+        {
+            var builder = new StringBuilder();
+            builder.AppendLine("Task:");
+            builder.AppendLine(GetTaskLabel(request.ResponseType));
+            builder.AppendLine();
+
+            if (!string.IsNullOrWhiteSpace(request.UserQuestion))
+            {
+                builder.AppendLine("User question:");
+                builder.AppendLine(request.UserQuestion.Trim());
+                builder.AppendLine();
+            }
+
+            builder.AppendLine("Dataset context JSON:");
+            builder.AppendLine(JsonSerializer.Serialize(request.DatasetContext, SerializerOptions));
+
+            if (request.EnrichmentContext != null)
+            {
+                builder.AppendLine();
+                builder.AppendLine("Additional enrichment JSON:");
+                builder.AppendLine(JsonSerializer.Serialize(request.EnrichmentContext, SerializerOptions));
+            }
+
+            builder.AppendLine();
+            builder.AppendLine("Response rules:");
+            builder.AppendLine(GetResponseRules(request.ResponseType));
+            return builder.ToString().Trim();
+        }
+
+        /// <summary>
+        /// Gets the concise task label included in the prompt body.
+        /// </summary>
+        private static string GetTaskLabel(AIResponseType responseType)
+        {
+            return responseType switch
+            {
+                AIResponseType.Summary => "Generate a dataset summary.",
+                AIResponseType.Insight => "Generate concise data-quality insights.",
+                AIResponseType.Recommendation => "Generate cleaning and transformation recommendations.",
+                AIResponseType.QuestionAnswer => "Answer the user's dataset question.",
+                _ => "Explain the dataset context."
+            };
+        }
+
+        /// <summary>
+        /// Gets the task-specific output rules that keep responses concise and useful.
+        /// </summary>
+        private static string GetResponseRules(AIResponseType responseType)
+        {
+            return responseType switch
+            {
+                AIResponseType.Summary => "Use at most two short paragraphs or four bullet points. Mention structure, quality, and one notable risk.",
+                AIResponseType.Insight => "List up to three findings. Prioritize nulls, anomalies, duplicates, and schema issues.",
+                AIResponseType.Recommendation => "List up to four prioritized actions. Include a brief why for each action and mention relevant transformations when applicable.",
+                AIResponseType.QuestionAnswer => "Answer first in one short paragraph, then add up to three short evidence bullets if needed.",
+                _ => "Keep the answer short and grounded."
+            };
+        }
+    }
+}

--- a/aspnet-core/src/AstraLab.Application/Services/AI/AiPromptBuilder.cs
+++ b/aspnet-core/src/AstraLab.Application/Services/AI/AiPromptBuilder.cs
@@ -29,7 +29,11 @@ namespace AstraLab.Services.AI
         {
             return new AiPromptBuildResult
             {
-                SystemInstructions = BuildSystemInstructions(request.ResponseType, request.IsAutomaticProfilingInsight),
+                SystemInstructions = BuildSystemInstructions(
+                    request.ResponseType,
+                    request.IsAutomaticProfilingInsight,
+                    request.IsAutomaticExperimentInsight,
+                    request.MlExperimentContext != null),
                 UserMessage = BuildUserMessage(request)
             };
         }
@@ -37,7 +41,11 @@ namespace AstraLab.Services.AI
         /// <summary>
         /// Builds the task-specific system prompt.
         /// </summary>
-        private static string BuildSystemInstructions(AIResponseType responseType, bool isAutomaticProfilingInsight)
+        private static string BuildSystemInstructions(
+            AIResponseType responseType,
+            bool isAutomaticProfilingInsight,
+            bool isAutomaticExperimentInsight,
+            bool hasMlExperimentContext)
         {
             if (isAutomaticProfilingInsight)
             {
@@ -46,17 +54,19 @@ namespace AstraLab.Services.AI
                        "Return exactly four short sections titled Summary, Key data quality issues, Notable patterns or anomalies, and Suggested next steps.";
             }
 
-            var taskGuidance = responseType switch
+            if (isAutomaticExperimentInsight)
             {
-                AIResponseType.Summary => "Write a concise dataset summary with a short overview and the most important risks.",
-                AIResponseType.Insight => "Identify the most important data-quality and structure insights. Focus on the top findings only.",
-                AIResponseType.Recommendation => "Recommend prioritized cleaning and transformation actions with brief rationale and expected impact.",
-                AIResponseType.QuestionAnswer => "Answer the user's question directly first, then support it with brief evidence from the dataset context.",
-                _ => "Provide a concise and grounded explanation based only on the supplied dataset context."
-            };
+                return "You are AstraLab's machine learning assistant. Use only the provided dataset context, enrichment, and machine learning experiment context. " +
+                       "Do not invent raw values, rows, metrics, or external facts. Write for a non-technical user in clear, plain language. " +
+                       "If the experiment is incomplete or missing model output, say so clearly. " +
+                       "Return exactly four short sections titled Summary, How the result looks, Risks or limitations, and Suggested next steps.";
+            }
 
-            return "You are AstraLab's dataset assistant. Use only the provided dataset context and enrichment. Do not invent raw values, rows, or external facts. " +
-                   "Be concise, practical, and specific. When context is missing, say so clearly. " +
+            var taskGuidance = GetTaskGuidance(responseType, hasMlExperimentContext);
+
+            return "You are AstraLab's dataset assistant. Use only the provided dataset context, enrichment, and any supplied machine learning experiment context. " +
+                   "Do not invent raw values, rows, metrics, or external facts. Be concise, practical, and specific. " +
+                   "When context is missing or an experiment is incomplete, say so clearly. " +
                    taskGuidance;
         }
 
@@ -67,7 +77,11 @@ namespace AstraLab.Services.AI
         {
             var builder = new StringBuilder();
             builder.AppendLine("Task:");
-            builder.AppendLine(GetTaskLabel(request.ResponseType, request.IsAutomaticProfilingInsight));
+            builder.AppendLine(GetTaskLabel(
+                request.ResponseType,
+                request.IsAutomaticProfilingInsight,
+                request.IsAutomaticExperimentInsight,
+                request.MlExperimentContext != null));
             builder.AppendLine();
 
             if (!string.IsNullOrWhiteSpace(request.UserQuestion))
@@ -87,28 +101,50 @@ namespace AstraLab.Services.AI
                 builder.AppendLine(JsonSerializer.Serialize(request.EnrichmentContext, SerializerOptions));
             }
 
+            if (request.MlExperimentContext != null)
+            {
+                builder.AppendLine();
+                builder.AppendLine("Machine learning experiment context JSON:");
+                builder.AppendLine(JsonSerializer.Serialize(request.MlExperimentContext, SerializerOptions));
+            }
+
             builder.AppendLine();
             builder.AppendLine("Response rules:");
-            builder.AppendLine(GetResponseRules(request.ResponseType, request.IsAutomaticProfilingInsight));
+            builder.AppendLine(GetResponseRules(
+                request.ResponseType,
+                request.IsAutomaticProfilingInsight,
+                request.IsAutomaticExperimentInsight,
+                request.MlExperimentContext != null));
             return builder.ToString().Trim();
         }
 
         /// <summary>
         /// Gets the concise task label included in the prompt body.
         /// </summary>
-        private static string GetTaskLabel(AIResponseType responseType, bool isAutomaticProfilingInsight)
+        private static string GetTaskLabel(AIResponseType responseType, bool isAutomaticProfilingInsight, bool isAutomaticExperimentInsight = false, bool hasMlExperimentContext = false)
         {
             if (isAutomaticProfilingInsight)
             {
                 return "Generate an automatic dataset insight after profiling completed.";
             }
 
+            if (isAutomaticExperimentInsight)
+            {
+                return "Generate an automatic machine learning experiment insight after the run completed.";
+            }
+
             return responseType switch
             {
-                AIResponseType.Summary => "Generate a dataset summary.",
+                AIResponseType.Summary => hasMlExperimentContext
+                    ? "Generate a machine learning experiment summary."
+                    : "Generate a dataset summary.",
                 AIResponseType.Insight => "Generate concise data-quality insights.",
-                AIResponseType.Recommendation => "Generate cleaning and transformation recommendations.",
-                AIResponseType.QuestionAnswer => "Answer the user's dataset question.",
+                AIResponseType.Recommendation => hasMlExperimentContext
+                    ? "Generate machine learning experiment recommendations."
+                    : "Generate cleaning and transformation recommendations.",
+                AIResponseType.QuestionAnswer => hasMlExperimentContext
+                    ? "Answer the user's machine learning experiment question."
+                    : "Answer the user's dataset question.",
                 _ => "Explain the dataset context."
             };
         }
@@ -116,7 +152,11 @@ namespace AstraLab.Services.AI
         /// <summary>
         /// Gets the task-specific output rules that keep responses concise and useful.
         /// </summary>
-        private static string GetResponseRules(AIResponseType responseType, bool isAutomaticProfilingInsight)
+        private static string GetResponseRules(
+            AIResponseType responseType,
+            bool isAutomaticProfilingInsight,
+            bool isAutomaticExperimentInsight,
+            bool hasMlExperimentContext)
         {
             if (isAutomaticProfilingInsight)
             {
@@ -124,13 +164,51 @@ namespace AstraLab.Services.AI
                        "Keep each section short, plain-language, and grounded in the provided profiling and schema context only.";
             }
 
+            if (isAutomaticExperimentInsight)
+            {
+                return "Use exactly these headings in order: Summary, How the result looks, Risks or limitations, Suggested next steps. " +
+                       "Keep each section short, plain-language, and grounded in the provided dataset, experiment, metric, and feature-importance context only.";
+            }
+
             return responseType switch
             {
-                AIResponseType.Summary => "Use at most two short paragraphs or four bullet points. Mention structure, quality, and one notable risk.",
+                AIResponseType.Summary => hasMlExperimentContext
+                    ? "Use at most two short paragraphs or four bullet points. Explain what the experiment tried, how the result looks, and one important limitation."
+                    : "Use at most two short paragraphs or four bullet points. Mention structure, quality, and one notable risk.",
                 AIResponseType.Insight => "List up to three findings. Prioritize nulls, anomalies, duplicates, and schema issues.",
-                AIResponseType.Recommendation => "List up to four prioritized actions. Include a brief why for each action and mention relevant transformations when applicable.",
-                AIResponseType.QuestionAnswer => "Answer first in one short paragraph, then add up to three short evidence bullets if needed.",
+                AIResponseType.Recommendation => hasMlExperimentContext
+                    ? "List up to four prioritized actions. Focus on next modeling, data preparation, or experiment-tuning steps with a brief why for each."
+                    : "List up to four prioritized actions. Include a brief why for each action and mention relevant transformations when applicable.",
+                AIResponseType.QuestionAnswer => hasMlExperimentContext
+                    ? "Answer first in one short paragraph, then add up to three short evidence bullets from the supplied metrics, warnings, feature importance, or dataset context if needed."
+                    : "Answer first in one short paragraph, then add up to three short evidence bullets if needed.",
                 _ => "Keep the answer short and grounded."
+            };
+        }
+
+        /// <summary>
+        /// Gets task guidance tailored to either dataset-only or experiment-aware AI requests.
+        /// </summary>
+        private static string GetTaskGuidance(AIResponseType responseType, bool hasMlExperimentContext)
+        {
+            if (hasMlExperimentContext)
+            {
+                return responseType switch
+                {
+                    AIResponseType.Summary => "Write a concise machine learning experiment summary explaining the setup, how the result looks, and the most important limitation.",
+                    AIResponseType.Recommendation => "Recommend prioritized next modeling, validation, or data-preparation actions with brief rationale.",
+                    AIResponseType.QuestionAnswer => "Answer the user's question directly first, then support it with brief evidence from the dataset and machine learning experiment context.",
+                    _ => "Provide a concise and grounded explanation based only on the supplied dataset and machine learning experiment context."
+                };
+            }
+
+            return responseType switch
+            {
+                AIResponseType.Summary => "Write a concise dataset summary with a short overview and the most important risks.",
+                AIResponseType.Insight => "Identify the most important data-quality and structure insights. Focus on the top findings only.",
+                AIResponseType.Recommendation => "Recommend prioritized cleaning and transformation actions with brief rationale and expected impact.",
+                AIResponseType.QuestionAnswer => "Answer the user's question directly first, then support it with brief evidence from the dataset context.",
+                _ => "Provide a concise and grounded explanation based only on the supplied dataset context."
             };
         }
     }

--- a/aspnet-core/src/AstraLab.Application/Services/AI/AiSchemaContext.cs
+++ b/aspnet-core/src/AstraLab.Application/Services/AI/AiSchemaContext.cs
@@ -1,0 +1,28 @@
+namespace AstraLab.Services.AI
+{
+    /// <summary>
+    /// Represents the schema-level summary included in AI context assembly.
+    /// </summary>
+    public class AiSchemaContext
+    {
+        /// <summary>
+        /// Gets or sets the total number of persisted columns for the selected dataset version.
+        /// </summary>
+        public int TotalColumnCount { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether a serialized schema payload exists.
+        /// </summary>
+        public bool HasSchemaJson { get; set; }
+
+        /// <summary>
+        /// Gets or sets the compact serialized schema preview.
+        /// </summary>
+        public string SchemaJsonPreview { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the serialized schema preview was truncated.
+        /// </summary>
+        public bool SchemaJsonWasTruncated { get; set; }
+    }
+}

--- a/aspnet-core/src/AstraLab.Application/Services/AI/AiTextGenerationRequest.cs
+++ b/aspnet-core/src/AstraLab.Application/Services/AI/AiTextGenerationRequest.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+
+namespace AstraLab.Services.AI
+{
+    /// <summary>
+    /// Represents a provider-neutral text-generation request.
+    /// </summary>
+    public class AiTextGenerationRequest
+    {
+        /// <summary>
+        /// Gets or sets the system-level instructions for the model.
+        /// </summary>
+        public string SystemInstructions { get; set; }
+
+        /// <summary>
+        /// Gets or sets the replayed prior conversation history.
+        /// </summary>
+        public IReadOnlyList<AiConversationHistoryMessage> ConversationHistory { get; set; }
+
+        /// <summary>
+        /// Gets or sets the final user prompt.
+        /// </summary>
+        public string UserMessage { get; set; }
+    }
+}

--- a/aspnet-core/src/AstraLab.Application/Services/AI/AiTextGenerationResult.cs
+++ b/aspnet-core/src/AstraLab.Application/Services/AI/AiTextGenerationResult.cs
@@ -1,0 +1,33 @@
+namespace AstraLab.Services.AI
+{
+    /// <summary>
+    /// Represents a provider-neutral text-generation result.
+    /// </summary>
+    public class AiTextGenerationResult
+    {
+        /// <summary>
+        /// Gets or sets the final generated text.
+        /// </summary>
+        public string Text { get; set; }
+
+        /// <summary>
+        /// Gets or sets the provider name that generated the text.
+        /// </summary>
+        public string Provider { get; set; }
+
+        /// <summary>
+        /// Gets or sets the provider model name when available.
+        /// </summary>
+        public string Model { get; set; }
+
+        /// <summary>
+        /// Gets or sets the provider response identifier when available.
+        /// </summary>
+        public string ProviderResponseId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the optional serialized usage metadata.
+        /// </summary>
+        public string UsageJson { get; set; }
+    }
+}

--- a/aspnet-core/src/AstraLab.Application/Services/AI/AiTransformationHistoryContext.cs
+++ b/aspnet-core/src/AstraLab.Application/Services/AI/AiTransformationHistoryContext.cs
@@ -1,0 +1,46 @@
+using System;
+using AstraLab.Core.Domains.Datasets;
+
+namespace AstraLab.Services.AI
+{
+    /// <summary>
+    /// Represents a compact transformation-history row used in AI enrichment.
+    /// </summary>
+    public class AiTransformationHistoryContext
+    {
+        /// <summary>
+        /// Gets or sets the dataset transformation identifier.
+        /// </summary>
+        public long DatasetTransformationId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the transformation type.
+        /// </summary>
+        public DatasetTransformationType TransformationType { get; set; }
+
+        /// <summary>
+        /// Gets or sets the source dataset version identifier.
+        /// </summary>
+        public long SourceDatasetVersionId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the result dataset version identifier.
+        /// </summary>
+        public long? ResultDatasetVersionId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the execution order.
+        /// </summary>
+        public int ExecutionOrder { get; set; }
+
+        /// <summary>
+        /// Gets or sets the execution timestamp.
+        /// </summary>
+        public DateTime ExecutedAt { get; set; }
+
+        /// <summary>
+        /// Gets or sets the compact execution summary payload when available.
+        /// </summary>
+        public string SummaryJson { get; set; }
+    }
+}

--- a/aspnet-core/src/AstraLab.Application/Services/AI/DatasetAiAppService.cs
+++ b/aspnet-core/src/AstraLab.Application/Services/AI/DatasetAiAppService.cs
@@ -7,6 +7,7 @@ using Abp.Runtime.Session;
 using Abp.UI;
 using AstraLab.Authorization;
 using AstraLab.Core.Domains.AI;
+using AstraLab.Core.Domains.ML;
 using AstraLab.Services.Datasets;
 using AstraLab.Services.AI.Dto;
 using Microsoft.EntityFrameworkCore;
@@ -26,6 +27,7 @@ namespace AstraLab.Services.AI
         private readonly IAiDatasetResponseGenerator _aiDatasetResponseGenerator;
         private readonly IRepository<AIConversation, long> _aiConversationRepository;
         private readonly IRepository<AIResponse, long> _aiResponseRepository;
+        private readonly IRepository<MLExperiment, long> _mlExperimentRepository;
         private readonly IDatasetOwnershipAccessChecker _datasetOwnershipAccessChecker;
 
         /// <summary>
@@ -35,11 +37,13 @@ namespace AstraLab.Services.AI
             IAiDatasetResponseGenerator aiDatasetResponseGenerator,
             IRepository<AIConversation, long> aiConversationRepository,
             IRepository<AIResponse, long> aiResponseRepository,
+            IRepository<MLExperiment, long> mlExperimentRepository,
             IDatasetOwnershipAccessChecker datasetOwnershipAccessChecker)
         {
             _aiDatasetResponseGenerator = aiDatasetResponseGenerator;
             _aiConversationRepository = aiConversationRepository;
             _aiResponseRepository = aiResponseRepository;
+            _mlExperimentRepository = mlExperimentRepository;
             _datasetOwnershipAccessChecker = datasetOwnershipAccessChecker;
         }
 
@@ -80,6 +84,36 @@ namespace AstraLab.Services.AI
         }
 
         /// <summary>
+        /// Generates a concise summary for the selected machine learning experiment.
+        /// </summary>
+        public async Task<GenerateDatasetAiResponseResult> GenerateExperimentSummaryAsync(EntityDto<long> mlExperimentId)
+        {
+            var experiment = await GetValidatedExperimentAsync(mlExperimentId.Id, GetRequiredTenantId(), AbpSession.GetUserId());
+
+            return await _aiDatasetResponseGenerator.GenerateAsync(
+                AIResponseType.Summary,
+                experiment.DatasetVersionId,
+                GetRequiredTenantId(),
+                AbpSession.GetUserId(),
+                mlExperimentId: experiment.Id);
+        }
+
+        /// <summary>
+        /// Generates concise next-step recommendations for the selected machine learning experiment.
+        /// </summary>
+        public async Task<GenerateDatasetAiResponseResult> GenerateExperimentRecommendationsAsync(EntityDto<long> mlExperimentId)
+        {
+            var experiment = await GetValidatedExperimentAsync(mlExperimentId.Id, GetRequiredTenantId(), AbpSession.GetUserId());
+
+            return await _aiDatasetResponseGenerator.GenerateAsync(
+                AIResponseType.Recommendation,
+                experiment.DatasetVersionId,
+                GetRequiredTenantId(),
+                AbpSession.GetUserId(),
+                mlExperimentId: experiment.Id);
+        }
+
+        /// <summary>
         /// Answers a grounded natural-language question about the selected dataset version.
         /// </summary>
         public Task<GenerateDatasetAiResponseResult> AskAsync(AskDatasetAiQuestionRequest input)
@@ -91,6 +125,23 @@ namespace AstraLab.Services.AI
                 AbpSession.GetUserId(),
                 input.Question,
                 input.ConversationId);
+        }
+
+        /// <summary>
+        /// Answers a grounded natural-language question about the selected machine learning experiment.
+        /// </summary>
+        public async Task<GenerateDatasetAiResponseResult> AskExperimentAsync(AskExperimentAiQuestionRequest input)
+        {
+            var experiment = await GetValidatedExperimentAsync(input.MLExperimentId, GetRequiredTenantId(), AbpSession.GetUserId());
+
+            return await _aiDatasetResponseGenerator.GenerateAsync(
+                AIResponseType.QuestionAnswer,
+                experiment.DatasetVersionId,
+                GetRequiredTenantId(),
+                AbpSession.GetUserId(),
+                input.Question,
+                input.ConversationId,
+                experiment.Id);
         }
 
         /// <summary>
@@ -124,6 +175,22 @@ namespace AstraLab.Services.AI
                 }
             }
 
+            if (input.MLExperimentId.HasValue)
+            {
+                var experiment = await GetValidatedExperimentAsync(input.MLExperimentId.Value, tenantId, ownerUserId);
+                var datasetVersion = await _datasetOwnershipAccessChecker.GetDatasetVersionForOwnerAsync(experiment.DatasetVersionId, tenantId, ownerUserId);
+
+                if (datasetVersion.DatasetId != input.DatasetId)
+                {
+                    throw new UserFriendlyException("The selected ML experiment does not belong to the requested dataset.");
+                }
+
+                if (input.DatasetVersionId.HasValue && input.DatasetVersionId.Value != experiment.DatasetVersionId)
+                {
+                    throw new UserFriendlyException("The selected ML experiment does not belong to the requested dataset version.");
+                }
+            }
+
             var responseQuery = _aiResponseRepository.GetAll();
             var conversationQuery = _aiConversationRepository.GetAll()
                 .Where(item =>
@@ -138,6 +205,15 @@ namespace AstraLab.Services.AI
                     responseQuery.Any(response =>
                         response.AIConversationId == item.Id &&
                         response.DatasetVersionId == datasetVersionId));
+            }
+
+            if (input.MLExperimentId.HasValue)
+            {
+                var mlExperimentId = input.MLExperimentId.Value;
+                conversationQuery = conversationQuery.Where(item =>
+                    responseQuery.Any(response =>
+                        response.AIConversationId == item.Id &&
+                        response.MLExperimentId == mlExperimentId));
             }
 
             var totalCount = await conversationQuery.CountAsync();
@@ -213,6 +289,31 @@ namespace AstraLab.Services.AI
                 : ObjectMapper.Map<AIResponseDto>(response);
         }
 
+        /// <summary>
+        /// Gets the latest experiment-completed automatic insight for the selected machine learning experiment when one exists.
+        /// </summary>
+        public async Task<AIResponseDto> GetLatestAutomaticExperimentInsightAsync(EntityDto<long> mlExperimentId)
+        {
+            var tenantId = GetRequiredTenantId();
+            await GetValidatedExperimentAsync(mlExperimentId.Id, tenantId, AbpSession.GetUserId());
+
+            var latestAutomaticInsight = await _aiResponseRepository.GetAll()
+                .Where(item =>
+                    item.TenantId == tenantId &&
+                    item.MLExperimentId == mlExperimentId.Id &&
+                    item.ResponseType == AIResponseType.Insight)
+                .OrderByDescending(item => item.CreationTime)
+                .ThenByDescending(item => item.Id)
+                .ToListAsync();
+
+            var response = latestAutomaticInsight
+                .FirstOrDefault(item => AiAutomaticInsightMetadata.IsAutomaticExperimentInsight(item.MetadataJson));
+
+            return response == null
+                ? null
+                : ObjectMapper.Map<AIResponseDto>(response);
+        }
+
         private int GetRequiredTenantId()
         {
             if (!AbpSession.TenantId.HasValue)
@@ -242,6 +343,27 @@ namespace AstraLab.Services.AI
 
             await _datasetOwnershipAccessChecker.GetDatasetForOwnerAsync(conversation.DatasetId, tenantId, ownerUserId);
             return conversation;
+        }
+
+        /// <summary>
+        /// Gets a tenant-owned machine learning experiment scoped to the current dataset owner.
+        /// </summary>
+        private async Task<MLExperiment> GetValidatedExperimentAsync(long mlExperimentId, int tenantId, long ownerUserId)
+        {
+            var experiment = await _mlExperimentRepository.GetAll()
+                .Where(item =>
+                    item.Id == mlExperimentId &&
+                    item.TenantId == tenantId &&
+                    item.DatasetVersion.TenantId == tenantId &&
+                    item.DatasetVersion.Dataset.OwnerUserId == ownerUserId)
+                .SingleOrDefaultAsync();
+
+            if (experiment == null)
+            {
+                throw new UserFriendlyException("The requested ML experiment could not be found.");
+            }
+
+            return experiment;
         }
 
         /// <summary>
@@ -296,6 +418,7 @@ namespace AstraLab.Services.AI
                 ResponseCount = responses?.Count ?? 0,
                 LatestDatasetVersionId = latestResponse?.DatasetVersionId,
                 LatestResponseType = latestResponse?.ResponseType,
+                LatestMLExperimentId = latestResponse?.MLExperimentId,
                 LatestUserQuery = latestResponse?.UserQuery,
                 LatestResponsePreview = BuildResponsePreview(latestResponse?.ResponseContent)
             };

--- a/aspnet-core/src/AstraLab.Application/Services/AI/DatasetAiAppService.cs
+++ b/aspnet-core/src/AstraLab.Application/Services/AI/DatasetAiAppService.cs
@@ -1,11 +1,17 @@
 using System.Threading.Tasks;
 using Abp.Application.Services.Dto;
 using Abp.Authorization;
+using Abp.Domain.Repositories;
+using Abp.Linq.Extensions;
 using Abp.Runtime.Session;
 using Abp.UI;
 using AstraLab.Authorization;
 using AstraLab.Core.Domains.AI;
+using AstraLab.Services.Datasets;
 using AstraLab.Services.AI.Dto;
+using Microsoft.EntityFrameworkCore;
+using System.Linq;
+using System.Collections.Generic;
 
 namespace AstraLab.Services.AI
 {
@@ -15,14 +21,26 @@ namespace AstraLab.Services.AI
     [AbpAuthorize(PermissionNames.Pages_Datasets)]
     public class DatasetAiAppService : AstraLabAppServiceBase, IDatasetAiAppService
     {
+        private const int RESPONSE_PREVIEW_MAX_LENGTH = 180;
+
         private readonly IAiDatasetResponseGenerator _aiDatasetResponseGenerator;
+        private readonly IRepository<AIConversation, long> _aiConversationRepository;
+        private readonly IRepository<AIResponse, long> _aiResponseRepository;
+        private readonly IDatasetOwnershipAccessChecker _datasetOwnershipAccessChecker;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DatasetAiAppService"/> class.
         /// </summary>
-        public DatasetAiAppService(IAiDatasetResponseGenerator aiDatasetResponseGenerator)
+        public DatasetAiAppService(
+            IAiDatasetResponseGenerator aiDatasetResponseGenerator,
+            IRepository<AIConversation, long> aiConversationRepository,
+            IRepository<AIResponse, long> aiResponseRepository,
+            IDatasetOwnershipAccessChecker datasetOwnershipAccessChecker)
         {
             _aiDatasetResponseGenerator = aiDatasetResponseGenerator;
+            _aiConversationRepository = aiConversationRepository;
+            _aiResponseRepository = aiResponseRepository;
+            _datasetOwnershipAccessChecker = datasetOwnershipAccessChecker;
         }
 
         /// <summary>
@@ -75,6 +93,126 @@ namespace AstraLab.Services.AI
                 input.ConversationId);
         }
 
+        /// <summary>
+        /// Gets a persisted AI conversation summary for the selected conversation.
+        /// </summary>
+        public async Task<AIConversationDto> GetConversationAsync(EntityDto<long> conversationId)
+        {
+            var tenantId = GetRequiredTenantId();
+            var ownerUserId = AbpSession.GetUserId();
+            var conversation = await GetValidatedConversationAsync(conversationId.Id, tenantId, ownerUserId);
+
+            return await BuildConversationDtoAsync(conversation);
+        }
+
+        /// <summary>
+        /// Gets persisted AI conversations for the selected dataset or dataset version.
+        /// </summary>
+        public async Task<PagedResultDto<AIConversationDto>> GetConversationsAsync(GetDatasetAiConversationsRequest input)
+        {
+            var tenantId = GetRequiredTenantId();
+            var ownerUserId = AbpSession.GetUserId();
+            await _datasetOwnershipAccessChecker.GetDatasetForOwnerAsync(input.DatasetId, tenantId, ownerUserId);
+
+            if (input.DatasetVersionId.HasValue)
+            {
+                var datasetVersion = await _datasetOwnershipAccessChecker.GetDatasetVersionForOwnerAsync(input.DatasetVersionId.Value, tenantId, ownerUserId);
+
+                if (datasetVersion.DatasetId != input.DatasetId)
+                {
+                    throw new UserFriendlyException("The selected dataset version does not belong to the requested dataset.");
+                }
+            }
+
+            var responseQuery = _aiResponseRepository.GetAll();
+            var conversationQuery = _aiConversationRepository.GetAll()
+                .Where(item =>
+                    item.TenantId == tenantId &&
+                    item.OwnerUserId == ownerUserId &&
+                    item.DatasetId == input.DatasetId);
+
+            if (input.DatasetVersionId.HasValue)
+            {
+                var datasetVersionId = input.DatasetVersionId.Value;
+                conversationQuery = conversationQuery.Where(item =>
+                    responseQuery.Any(response =>
+                        response.AIConversationId == item.Id &&
+                        response.DatasetVersionId == datasetVersionId));
+            }
+
+            var totalCount = await conversationQuery.CountAsync();
+            var pagedConversations = await conversationQuery
+                .OrderByDescending(item => item.LastInteractionTime)
+                .ThenByDescending(item => item.Id)
+                .PageBy(input)
+                .ToListAsync();
+            var conversationIds = pagedConversations.Select(item => item.Id).ToList();
+            var responseLookup = await GetConversationResponseLookupAsync(conversationIds);
+
+            return new PagedResultDto<AIConversationDto>(
+                totalCount,
+                pagedConversations
+                    .Select(item =>
+                    {
+                        responseLookup.TryGetValue(item.Id, out var responses);
+                        return BuildConversationDto(item, responses);
+                    })
+                    .ToList());
+        }
+
+        /// <summary>
+        /// Gets persisted AI responses for the selected conversation thread.
+        /// </summary>
+        public async Task<PagedResultDto<AIResponseDto>> GetResponsesAsync(GetDatasetAiResponsesRequest input)
+        {
+            var tenantId = GetRequiredTenantId();
+            var ownerUserId = AbpSession.GetUserId();
+            await GetValidatedConversationAsync(input.ConversationId, tenantId, ownerUserId);
+
+            var query = _aiResponseRepository.GetAll()
+                .Where(item =>
+                    item.TenantId == tenantId &&
+                    item.AIConversationId == input.ConversationId);
+            var totalCount = await query.CountAsync();
+
+            query = input.IsChronological
+                ? query.OrderBy(item => item.CreationTime).ThenBy(item => item.Id)
+                : query.OrderByDescending(item => item.CreationTime).ThenByDescending(item => item.Id);
+
+            var responses = await query
+                .PageBy(input)
+                .ToListAsync();
+
+            return new PagedResultDto<AIResponseDto>(
+                totalCount,
+                ObjectMapper.Map<List<AIResponseDto>>(responses));
+        }
+
+        /// <summary>
+        /// Gets the latest profiling-triggered automatic insight for the selected dataset version when one exists.
+        /// </summary>
+        public async Task<AIResponseDto> GetLatestAutomaticInsightAsync(EntityDto<long> datasetVersionId)
+        {
+            var tenantId = GetRequiredTenantId();
+            await _datasetOwnershipAccessChecker.GetDatasetVersionForOwnerAsync(datasetVersionId.Id, tenantId, AbpSession.GetUserId());
+
+            var latestAutomaticInsight = await _aiResponseRepository.GetAll()
+                .Where(item =>
+                    item.TenantId == tenantId &&
+                    item.DatasetVersionId == datasetVersionId.Id &&
+                    item.ResponseType == AIResponseType.Insight)
+                .OrderByDescending(item => item.CreationTime)
+                .ThenByDescending(item => item.Id)
+                .ToListAsync();
+
+            var response = latestAutomaticInsight
+                .FirstOrDefault(item => AiAutomaticInsightMetadata.IsAutomaticProfilingInsight(item.MetadataJson));
+
+            return response == null
+                ? null
+                : ObjectMapper.Map<AIResponseDto>(response);
+        }
+
         private int GetRequiredTenantId()
         {
             if (!AbpSession.TenantId.HasValue)
@@ -83,6 +221,100 @@ namespace AstraLab.Services.AI
             }
 
             return AbpSession.TenantId.Value;
+        }
+
+        /// <summary>
+        /// Gets a tenant-owned conversation and validates dataset ownership before returning it.
+        /// </summary>
+        private async Task<AIConversation> GetValidatedConversationAsync(long conversationId, int tenantId, long ownerUserId)
+        {
+            var conversation = await _aiConversationRepository.GetAll()
+                .Where(item =>
+                    item.Id == conversationId &&
+                    item.TenantId == tenantId &&
+                    item.OwnerUserId == ownerUserId)
+                .SingleOrDefaultAsync();
+
+            if (conversation == null)
+            {
+                throw new UserFriendlyException("The requested AI conversation could not be found.");
+            }
+
+            await _datasetOwnershipAccessChecker.GetDatasetForOwnerAsync(conversation.DatasetId, tenantId, ownerUserId);
+            return conversation;
+        }
+
+        /// <summary>
+        /// Builds a persisted AI conversation DTO including latest-response summary details.
+        /// </summary>
+        private async Task<AIConversationDto> BuildConversationDtoAsync(AIConversation conversation)
+        {
+            var responseLookup = await GetConversationResponseLookupAsync(new List<long> { conversation.Id });
+
+            responseLookup.TryGetValue(conversation.Id, out var responses);
+            return BuildConversationDto(conversation, responses);
+        }
+
+        /// <summary>
+        /// Loads persisted responses for the selected conversations so summary DTOs can be built efficiently.
+        /// </summary>
+        private async Task<Dictionary<long, List<AIResponse>>> GetConversationResponseLookupAsync(List<long> conversationIds)
+        {
+            if (conversationIds.Count == 0)
+            {
+                return new Dictionary<long, List<AIResponse>>();
+            }
+
+            var responses = await _aiResponseRepository.GetAll()
+                .Where(item => conversationIds.Contains(item.AIConversationId))
+                .OrderBy(item => item.CreationTime)
+                .ThenBy(item => item.Id)
+                .ToListAsync();
+
+            return responses
+                .GroupBy(item => item.AIConversationId)
+                .ToDictionary(item => item.Key, item => item.ToList());
+        }
+
+        /// <summary>
+        /// Maps a conversation and its persisted responses to a UI-friendly conversation summary DTO.
+        /// </summary>
+        private static AIConversationDto BuildConversationDto(AIConversation conversation, List<AIResponse> responses)
+        {
+            var latestResponse = responses?
+                .OrderByDescending(item => item.CreationTime)
+                .ThenByDescending(item => item.Id)
+                .FirstOrDefault();
+
+            return new AIConversationDto
+            {
+                Id = conversation.Id,
+                DatasetId = conversation.DatasetId,
+                OwnerUserId = conversation.OwnerUserId,
+                LastInteractionTime = conversation.LastInteractionTime,
+                CreationTime = conversation.CreationTime,
+                ResponseCount = responses?.Count ?? 0,
+                LatestDatasetVersionId = latestResponse?.DatasetVersionId,
+                LatestResponseType = latestResponse?.ResponseType,
+                LatestUserQuery = latestResponse?.UserQuery,
+                LatestResponsePreview = BuildResponsePreview(latestResponse?.ResponseContent)
+            };
+        }
+
+        /// <summary>
+        /// Trims persisted AI response content to a compact preview suitable for list rendering.
+        /// </summary>
+        private static string BuildResponsePreview(string responseContent)
+        {
+            if (string.IsNullOrWhiteSpace(responseContent))
+            {
+                return null;
+            }
+
+            var trimmedContent = responseContent.Trim();
+            return trimmedContent.Length <= RESPONSE_PREVIEW_MAX_LENGTH
+                ? trimmedContent
+                : trimmedContent.Substring(0, RESPONSE_PREVIEW_MAX_LENGTH - 1) + "…";
         }
     }
 }

--- a/aspnet-core/src/AstraLab.Application/Services/AI/DatasetAiAppService.cs
+++ b/aspnet-core/src/AstraLab.Application/Services/AI/DatasetAiAppService.cs
@@ -1,0 +1,88 @@
+using System.Threading.Tasks;
+using Abp.Application.Services.Dto;
+using Abp.Authorization;
+using Abp.Runtime.Session;
+using Abp.UI;
+using AstraLab.Authorization;
+using AstraLab.Core.Domains.AI;
+using AstraLab.Services.AI.Dto;
+
+namespace AstraLab.Services.AI
+{
+    /// <summary>
+    /// Exposes dataset-scoped AI generation workflows.
+    /// </summary>
+    [AbpAuthorize(PermissionNames.Pages_Datasets)]
+    public class DatasetAiAppService : AstraLabAppServiceBase, IDatasetAiAppService
+    {
+        private readonly IAiDatasetResponseGenerator _aiDatasetResponseGenerator;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DatasetAiAppService"/> class.
+        /// </summary>
+        public DatasetAiAppService(IAiDatasetResponseGenerator aiDatasetResponseGenerator)
+        {
+            _aiDatasetResponseGenerator = aiDatasetResponseGenerator;
+        }
+
+        /// <summary>
+        /// Generates a concise summary for the selected dataset version.
+        /// </summary>
+        public Task<GenerateDatasetAiResponseResult> GenerateSummaryAsync(EntityDto<long> datasetVersionId)
+        {
+            return _aiDatasetResponseGenerator.GenerateAsync(
+                AIResponseType.Summary,
+                datasetVersionId.Id,
+                GetRequiredTenantId(),
+                AbpSession.GetUserId());
+        }
+
+        /// <summary>
+        /// Generates concise data-quality insights for the selected dataset version.
+        /// </summary>
+        public Task<GenerateDatasetAiResponseResult> GenerateInsightsAsync(EntityDto<long> datasetVersionId)
+        {
+            return _aiDatasetResponseGenerator.GenerateAsync(
+                AIResponseType.Insight,
+                datasetVersionId.Id,
+                GetRequiredTenantId(),
+                AbpSession.GetUserId());
+        }
+
+        /// <summary>
+        /// Generates cleaning and transformation recommendations for the selected dataset version.
+        /// </summary>
+        public Task<GenerateDatasetAiResponseResult> GenerateCleaningRecommendationsAsync(EntityDto<long> datasetVersionId)
+        {
+            return _aiDatasetResponseGenerator.GenerateAsync(
+                AIResponseType.Recommendation,
+                datasetVersionId.Id,
+                GetRequiredTenantId(),
+                AbpSession.GetUserId());
+        }
+
+        /// <summary>
+        /// Answers a grounded natural-language question about the selected dataset version.
+        /// </summary>
+        public Task<GenerateDatasetAiResponseResult> AskAsync(AskDatasetAiQuestionRequest input)
+        {
+            return _aiDatasetResponseGenerator.GenerateAsync(
+                AIResponseType.QuestionAnswer,
+                input.DatasetVersionId,
+                GetRequiredTenantId(),
+                AbpSession.GetUserId(),
+                input.Question,
+                input.ConversationId);
+        }
+
+        private int GetRequiredTenantId()
+        {
+            if (!AbpSession.TenantId.HasValue)
+            {
+                throw new UserFriendlyException("Tenant context is required for dataset AI operations.");
+            }
+
+            return AbpSession.TenantId.Value;
+        }
+    }
+}

--- a/aspnet-core/src/AstraLab.Application/Services/AI/Dto/AIConversationDto.cs
+++ b/aspnet-core/src/AstraLab.Application/Services/AI/Dto/AIConversationDto.cs
@@ -30,5 +30,30 @@ namespace AstraLab.Services.AI.Dto
         /// Gets or sets the creation time of the persisted conversation.
         /// </summary>
         public DateTime CreationTime { get; set; }
+
+        /// <summary>
+        /// Gets or sets the number of persisted responses in the conversation.
+        /// </summary>
+        public int ResponseCount { get; set; }
+
+        /// <summary>
+        /// Gets or sets the latest dataset version identifier represented in the conversation.
+        /// </summary>
+        public long? LatestDatasetVersionId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the response type of the latest persisted AI response.
+        /// </summary>
+        public AIResponseType? LatestResponseType { get; set; }
+
+        /// <summary>
+        /// Gets or sets the optional latest user query that led to the current response.
+        /// </summary>
+        public string LatestUserQuery { get; set; }
+
+        /// <summary>
+        /// Gets or sets a short preview of the latest persisted response content.
+        /// </summary>
+        public string LatestResponsePreview { get; set; }
     }
 }

--- a/aspnet-core/src/AstraLab.Application/Services/AI/Dto/AIConversationDto.cs
+++ b/aspnet-core/src/AstraLab.Application/Services/AI/Dto/AIConversationDto.cs
@@ -47,6 +47,11 @@ namespace AstraLab.Services.AI.Dto
         public AIResponseType? LatestResponseType { get; set; }
 
         /// <summary>
+        /// Gets or sets the optional latest machine learning experiment identifier represented in the conversation.
+        /// </summary>
+        public long? LatestMLExperimentId { get; set; }
+
+        /// <summary>
         /// Gets or sets the optional latest user query that led to the current response.
         /// </summary>
         public string LatestUserQuery { get; set; }

--- a/aspnet-core/src/AstraLab.Application/Services/AI/Dto/AIConversationDto.cs
+++ b/aspnet-core/src/AstraLab.Application/Services/AI/Dto/AIConversationDto.cs
@@ -1,0 +1,34 @@
+using System;
+using Abp.Application.Services.Dto;
+using Abp.AutoMapper;
+using AstraLab.Core.Domains.AI;
+
+namespace AstraLab.Services.AI.Dto
+{
+    /// <summary>
+    /// Represents a persisted AI conversation thread returned by the application layer.
+    /// </summary>
+    [AutoMapFrom(typeof(AIConversation))]
+    public class AIConversationDto : EntityDto<long>
+    {
+        /// <summary>
+        /// Gets or sets the dataset identifier that scopes the conversation.
+        /// </summary>
+        public long DatasetId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the owning user identifier for the conversation.
+        /// </summary>
+        public long OwnerUserId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the timestamp of the latest interaction in the conversation.
+        /// </summary>
+        public DateTime LastInteractionTime { get; set; }
+
+        /// <summary>
+        /// Gets or sets the creation time of the persisted conversation.
+        /// </summary>
+        public DateTime CreationTime { get; set; }
+    }
+}

--- a/aspnet-core/src/AstraLab.Application/Services/AI/Dto/AIResponseDto.cs
+++ b/aspnet-core/src/AstraLab.Application/Services/AI/Dto/AIResponseDto.cs
@@ -42,6 +42,11 @@ namespace AstraLab.Services.AI.Dto
         public long? DatasetTransformationId { get; set; }
 
         /// <summary>
+        /// Gets or sets the optional linked machine learning experiment identifier.
+        /// </summary>
+        public long? MLExperimentId { get; set; }
+
+        /// <summary>
         /// Gets or sets the optional serialized metadata payload.
         /// </summary>
         public string MetadataJson { get; set; }

--- a/aspnet-core/src/AstraLab.Application/Services/AI/Dto/AIResponseDto.cs
+++ b/aspnet-core/src/AstraLab.Application/Services/AI/Dto/AIResponseDto.cs
@@ -1,0 +1,54 @@
+using System;
+using Abp.Application.Services.Dto;
+using Abp.AutoMapper;
+using AstraLab.Core.Domains.AI;
+
+namespace AstraLab.Services.AI.Dto
+{
+    /// <summary>
+    /// Represents a persisted AI response returned by the application layer.
+    /// </summary>
+    [AutoMapFrom(typeof(AIResponse))]
+    public class AIResponseDto : EntityDto<long>
+    {
+        /// <summary>
+        /// Gets or sets the conversation identifier that groups the response.
+        /// </summary>
+        public long AIConversationId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the dataset version identifier that grounds the response.
+        /// </summary>
+        public long DatasetVersionId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the optional user query that led to the response.
+        /// </summary>
+        public string UserQuery { get; set; }
+
+        /// <summary>
+        /// Gets or sets the persisted AI-generated response content.
+        /// </summary>
+        public string ResponseContent { get; set; }
+
+        /// <summary>
+        /// Gets or sets the response type used to classify the response.
+        /// </summary>
+        public AIResponseType ResponseType { get; set; }
+
+        /// <summary>
+        /// Gets or sets the optional linked dataset transformation identifier.
+        /// </summary>
+        public long? DatasetTransformationId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the optional serialized metadata payload.
+        /// </summary>
+        public string MetadataJson { get; set; }
+
+        /// <summary>
+        /// Gets or sets the creation time of the persisted response.
+        /// </summary>
+        public DateTime CreationTime { get; set; }
+    }
+}

--- a/aspnet-core/src/AstraLab.Application/Services/AI/Dto/AskDatasetAiQuestionRequest.cs
+++ b/aspnet-core/src/AstraLab.Application/Services/AI/Dto/AskDatasetAiQuestionRequest.cs
@@ -1,0 +1,23 @@
+namespace AstraLab.Services.AI.Dto
+{
+    /// <summary>
+    /// Requests a grounded natural-language answer for a dataset version.
+    /// </summary>
+    public class AskDatasetAiQuestionRequest
+    {
+        /// <summary>
+        /// Gets or sets the dataset version identifier that grounds the answer.
+        /// </summary>
+        public long DatasetVersionId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the user question that should be answered.
+        /// </summary>
+        public string Question { get; set; }
+
+        /// <summary>
+        /// Gets or sets the optional conversation identifier to continue.
+        /// </summary>
+        public long? ConversationId { get; set; }
+    }
+}

--- a/aspnet-core/src/AstraLab.Application/Services/AI/Dto/AskExperimentAiQuestionRequest.cs
+++ b/aspnet-core/src/AstraLab.Application/Services/AI/Dto/AskExperimentAiQuestionRequest.cs
@@ -1,0 +1,23 @@
+namespace AstraLab.Services.AI.Dto
+{
+    /// <summary>
+    /// Requests a grounded natural-language answer for a machine learning experiment.
+    /// </summary>
+    public class AskExperimentAiQuestionRequest
+    {
+        /// <summary>
+        /// Gets or sets the machine learning experiment identifier that grounds the answer.
+        /// </summary>
+        public long MLExperimentId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the user question that should be answered.
+        /// </summary>
+        public string Question { get; set; }
+
+        /// <summary>
+        /// Gets or sets the optional conversation identifier to continue.
+        /// </summary>
+        public long? ConversationId { get; set; }
+    }
+}

--- a/aspnet-core/src/AstraLab.Application/Services/AI/Dto/GenerateDatasetAiResponseResult.cs
+++ b/aspnet-core/src/AstraLab.Application/Services/AI/Dto/GenerateDatasetAiResponseResult.cs
@@ -1,0 +1,18 @@
+namespace AstraLab.Services.AI.Dto
+{
+    /// <summary>
+    /// Returns a persisted AI response together with its resolved conversation identifier.
+    /// </summary>
+    public class GenerateDatasetAiResponseResult
+    {
+        /// <summary>
+        /// Gets or sets the conversation identifier that groups the response.
+        /// </summary>
+        public long ConversationId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the persisted AI response.
+        /// </summary>
+        public AIResponseDto Response { get; set; }
+    }
+}

--- a/aspnet-core/src/AstraLab.Application/Services/AI/Dto/GetDatasetAiConversationsRequest.cs
+++ b/aspnet-core/src/AstraLab.Application/Services/AI/Dto/GetDatasetAiConversationsRequest.cs
@@ -16,5 +16,10 @@ namespace AstraLab.Services.AI.Dto
         /// Gets or sets the optional dataset version identifier used to narrow the returned conversations.
         /// </summary>
         public long? DatasetVersionId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the optional machine learning experiment identifier used to narrow the returned conversations.
+        /// </summary>
+        public long? MLExperimentId { get; set; }
     }
 }

--- a/aspnet-core/src/AstraLab.Application/Services/AI/Dto/GetDatasetAiConversationsRequest.cs
+++ b/aspnet-core/src/AstraLab.Application/Services/AI/Dto/GetDatasetAiConversationsRequest.cs
@@ -1,0 +1,20 @@
+using Abp.Application.Services.Dto;
+
+namespace AstraLab.Services.AI.Dto
+{
+    /// <summary>
+    /// Requests dataset-scoped persisted AI conversations for the selected dataset or dataset version.
+    /// </summary>
+    public class GetDatasetAiConversationsRequest : PagedResultRequestDto
+    {
+        /// <summary>
+        /// Gets or sets the dataset identifier that scopes the conversations.
+        /// </summary>
+        public long DatasetId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the optional dataset version identifier used to narrow the returned conversations.
+        /// </summary>
+        public long? DatasetVersionId { get; set; }
+    }
+}

--- a/aspnet-core/src/AstraLab.Application/Services/AI/Dto/GetDatasetAiResponsesRequest.cs
+++ b/aspnet-core/src/AstraLab.Application/Services/AI/Dto/GetDatasetAiResponsesRequest.cs
@@ -1,0 +1,20 @@
+using Abp.Application.Services.Dto;
+
+namespace AstraLab.Services.AI.Dto
+{
+    /// <summary>
+    /// Requests a persisted AI response thread for the selected conversation.
+    /// </summary>
+    public class GetDatasetAiResponsesRequest : PagedResultRequestDto
+    {
+        /// <summary>
+        /// Gets or sets the conversation identifier that owns the responses.
+        /// </summary>
+        public long ConversationId { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the thread should be returned in chronological order.
+        /// </summary>
+        public bool IsChronological { get; set; } = true;
+    }
+}

--- a/aspnet-core/src/AstraLab.Application/Services/AI/GenerateAutomaticDatasetInsightJob.cs
+++ b/aspnet-core/src/AstraLab.Application/Services/AI/GenerateAutomaticDatasetInsightJob.cs
@@ -1,0 +1,74 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Abp.BackgroundJobs;
+using Abp.Dependency;
+using Abp.Domain.Repositories;
+using AstraLab.Core.Domains.AI;
+using AstraLab.Core.Domains.Datasets;
+using AstraLab.Services.Datasets;
+using Microsoft.EntityFrameworkCore;
+
+namespace AstraLab.Services.AI
+{
+    /// <summary>
+    /// Generates a persisted automatic insight after profiling completes for a dataset version.
+    /// </summary>
+    public class GenerateAutomaticDatasetInsightJob : AsyncBackgroundJob<GenerateAutomaticDatasetInsightJobArgs>, ITransientDependency
+    {
+        private readonly IRepository<DatasetProfile, long> _datasetProfileRepository;
+        private readonly IRepository<AIResponse, long> _aiResponseRepository;
+        private readonly IDatasetOwnershipAccessChecker _datasetOwnershipAccessChecker;
+        private readonly IAiDatasetResponseGenerator _aiDatasetResponseGenerator;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GenerateAutomaticDatasetInsightJob"/> class.
+        /// </summary>
+        public GenerateAutomaticDatasetInsightJob(
+            IRepository<DatasetProfile, long> datasetProfileRepository,
+            IRepository<AIResponse, long> aiResponseRepository,
+            IDatasetOwnershipAccessChecker datasetOwnershipAccessChecker,
+            IAiDatasetResponseGenerator aiDatasetResponseGenerator)
+        {
+            _datasetProfileRepository = datasetProfileRepository;
+            _aiResponseRepository = aiResponseRepository;
+            _datasetOwnershipAccessChecker = datasetOwnershipAccessChecker;
+            _aiDatasetResponseGenerator = aiDatasetResponseGenerator;
+        }
+
+        /// <summary>
+        /// Executes the automatic insight generation workflow when the queued profile is still current.
+        /// </summary>
+        public override async Task ExecuteAsync(GenerateAutomaticDatasetInsightJobArgs args)
+        {
+            await _datasetOwnershipAccessChecker.GetDatasetVersionForOwnerAsync(args.DatasetVersionId, args.TenantId, args.OwnerUserId);
+
+            var currentProfile = await _datasetProfileRepository.GetAll()
+                .Where(item => item.TenantId == args.TenantId && item.DatasetVersionId == args.DatasetVersionId)
+                .SingleOrDefaultAsync();
+
+            if (currentProfile == null || currentProfile.Id != args.DatasetProfileId)
+            {
+                return;
+            }
+
+            var existingInsightMetadata = await _aiResponseRepository.GetAll()
+                .Where(item =>
+                    item.TenantId == args.TenantId &&
+                    item.DatasetVersionId == args.DatasetVersionId &&
+                    item.ResponseType == AIResponseType.Insight)
+                .Select(item => item.MetadataJson)
+                .ToListAsync();
+
+            if (existingInsightMetadata.Any(item => AiAutomaticInsightMetadata.IsAutomaticProfilingInsight(item, args.DatasetProfileId)))
+            {
+                return;
+            }
+
+            await _aiDatasetResponseGenerator.GenerateAutomaticInsightAsync(
+                args.DatasetVersionId,
+                args.DatasetProfileId,
+                args.TenantId,
+                args.OwnerUserId);
+        }
+    }
+}

--- a/aspnet-core/src/AstraLab.Application/Services/AI/GenerateAutomaticDatasetInsightJobArgs.cs
+++ b/aspnet-core/src/AstraLab.Application/Services/AI/GenerateAutomaticDatasetInsightJobArgs.cs
@@ -1,0 +1,28 @@
+namespace AstraLab.Services.AI
+{
+    /// <summary>
+    /// Represents the background-job payload used to generate automatic insights after profiling.
+    /// </summary>
+    public class GenerateAutomaticDatasetInsightJobArgs
+    {
+        /// <summary>
+        /// Gets or sets the profiled dataset version identifier.
+        /// </summary>
+        public long DatasetVersionId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the current dataset profile identifier that triggered the job.
+        /// </summary>
+        public long DatasetProfileId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the tenant that owns the dataset version.
+        /// </summary>
+        public int TenantId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the dataset owner that should be used for access validation.
+        /// </summary>
+        public long OwnerUserId { get; set; }
+    }
+}

--- a/aspnet-core/src/AstraLab.Application/Services/AI/GenerateAutomaticExperimentInsightJob.cs
+++ b/aspnet-core/src/AstraLab.Application/Services/AI/GenerateAutomaticExperimentInsightJob.cs
@@ -1,0 +1,79 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Abp.BackgroundJobs;
+using Abp.Dependency;
+using Abp.Domain.Repositories;
+using Abp.Domain.Uow;
+using AstraLab.Core.Domains.AI;
+using AstraLab.Core.Domains.ML;
+using Microsoft.EntityFrameworkCore;
+
+namespace AstraLab.Services.AI
+{
+    /// <summary>
+    /// Generates best-effort automatic AI insights for completed machine learning experiments.
+    /// </summary>
+    public class GenerateAutomaticExperimentInsightJob :
+        AsyncBackgroundJob<GenerateAutomaticExperimentInsightJobArgs>,
+        ITransientDependency
+    {
+        private readonly IRepository<MLExperiment, long> _mlExperimentRepository;
+        private readonly IRepository<AIResponse, long> _aiResponseRepository;
+        private readonly IAiDatasetResponseGenerator _aiDatasetResponseGenerator;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GenerateAutomaticExperimentInsightJob"/> class.
+        /// </summary>
+        public GenerateAutomaticExperimentInsightJob(
+            IRepository<MLExperiment, long> mlExperimentRepository,
+            IRepository<AIResponse, long> aiResponseRepository,
+            IAiDatasetResponseGenerator aiDatasetResponseGenerator)
+        {
+            _mlExperimentRepository = mlExperimentRepository;
+            _aiResponseRepository = aiResponseRepository;
+            _aiDatasetResponseGenerator = aiDatasetResponseGenerator;
+        }
+
+        /// <summary>
+        /// Generates the automatic insight when the experiment is still current, completed, and not already processed.
+        /// </summary>
+        [UnitOfWork]
+        public override async Task ExecuteAsync(GenerateAutomaticExperimentInsightJobArgs args)
+        {
+            var experiment = await _mlExperimentRepository.GetAll()
+                .Include(item => item.Model)
+                .Where(item =>
+                    item.Id == args.MLExperimentId &&
+                    item.TenantId == args.TenantId)
+                .SingleOrDefaultAsync();
+
+            if (experiment == null ||
+                experiment.DatasetVersionId != args.DatasetVersionId ||
+                experiment.Status != MLExperimentStatus.Completed ||
+                experiment.Model == null)
+            {
+                return;
+            }
+
+            var existingAutomaticInsight = await _aiResponseRepository.GetAll()
+                .Where(item =>
+                    item.TenantId == args.TenantId &&
+                    item.MLExperimentId == args.MLExperimentId &&
+                    item.ResponseType == AIResponseType.Insight)
+                .OrderByDescending(item => item.CreationTime)
+                .ThenByDescending(item => item.Id)
+                .ToListAsync();
+
+            if (existingAutomaticInsight.Any(item =>
+                    AiAutomaticInsightMetadata.IsAutomaticExperimentInsight(item.MetadataJson, args.MLExperimentId)))
+            {
+                return;
+            }
+
+            await _aiDatasetResponseGenerator.GenerateAutomaticExperimentInsightAsync(
+                args.MLExperimentId,
+                args.TenantId,
+                args.OwnerUserId);
+        }
+    }
+}

--- a/aspnet-core/src/AstraLab.Application/Services/AI/GenerateAutomaticExperimentInsightJobArgs.cs
+++ b/aspnet-core/src/AstraLab.Application/Services/AI/GenerateAutomaticExperimentInsightJobArgs.cs
@@ -1,0 +1,28 @@
+namespace AstraLab.Services.AI
+{
+    /// <summary>
+    /// Carries the tenant-owned machine learning experiment context required to generate an automatic AI insight.
+    /// </summary>
+    public class GenerateAutomaticExperimentInsightJobArgs
+    {
+        /// <summary>
+        /// Gets or sets the machine learning experiment identifier.
+        /// </summary>
+        public long MLExperimentId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the dataset version identifier that the experiment ran against.
+        /// </summary>
+        public long DatasetVersionId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the tenant identifier that owns the experiment.
+        /// </summary>
+        public int TenantId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the owner user identifier that owns the backing dataset.
+        /// </summary>
+        public long OwnerUserId { get; set; }
+    }
+}

--- a/aspnet-core/src/AstraLab.Application/Services/AI/GroqAiOptions.cs
+++ b/aspnet-core/src/AstraLab.Application/Services/AI/GroqAiOptions.cs
@@ -1,0 +1,38 @@
+namespace AstraLab.Services.AI
+{
+    /// <summary>
+    /// Represents the configured Groq text-generation settings.
+    /// </summary>
+    public class GroqAiOptions
+    {
+        /// <summary>
+        /// Gets or sets the Groq base URL.
+        /// </summary>
+        public string BaseUrl { get; set; }
+
+        /// <summary>
+        /// Gets or sets the Groq API key.
+        /// </summary>
+        public string ApiKey { get; set; }
+
+        /// <summary>
+        /// Gets or sets the default model name.
+        /// </summary>
+        public string Model { get; set; }
+
+        /// <summary>
+        /// Gets or sets the request timeout in seconds.
+        /// </summary>
+        public int TimeoutSeconds { get; set; }
+
+        /// <summary>
+        /// Gets or sets the maximum output tokens.
+        /// </summary>
+        public int MaxOutputTokens { get; set; }
+
+        /// <summary>
+        /// Gets or sets the optional reasoning effort.
+        /// </summary>
+        public string ReasoningEffort { get; set; }
+    }
+}

--- a/aspnet-core/src/AstraLab.Application/Services/AI/GroqAiTextGenerationClient.cs
+++ b/aspnet-core/src/AstraLab.Application/Services/AI/GroqAiTextGenerationClient.cs
@@ -1,0 +1,284 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+using Abp.Dependency;
+using Abp.UI;
+
+namespace AstraLab.Services.AI
+{
+    /// <summary>
+    /// Calls Groq's OpenAI-compatible Responses API to generate dataset-grounded text.
+    /// </summary>
+    public class GroqAiTextGenerationClient : IAiTextGenerationClient, ITransientDependency
+    {
+        private static readonly JsonSerializerOptions SerializerOptions = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+        };
+
+        private readonly IHttpClientFactory _httpClientFactory;
+        private readonly GroqAiOptions _groqAiOptions;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GroqAiTextGenerationClient"/> class.
+        /// </summary>
+        public GroqAiTextGenerationClient(IHttpClientFactory httpClientFactory, GroqAiOptions groqAiOptions)
+        {
+            _httpClientFactory = httpClientFactory;
+            _groqAiOptions = groqAiOptions;
+        }
+
+        /// <summary>
+        /// Generates text for the supplied request.
+        /// </summary>
+        public async Task<AiTextGenerationResult> GenerateTextAsync(AiTextGenerationRequest request)
+        {
+            ValidateConfiguration();
+
+            var client = _httpClientFactory.CreateClient();
+            client.Timeout = TimeSpan.FromSeconds(_groqAiOptions.TimeoutSeconds > 0 ? _groqAiOptions.TimeoutSeconds : 60);
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _groqAiOptions.ApiKey);
+
+            var payload = new GroqResponsesRequest
+            {
+                Model = _groqAiOptions.Model,
+                MaxOutputTokens = _groqAiOptions.MaxOutputTokens > 0 ? _groqAiOptions.MaxOutputTokens : 800,
+                Input = BuildInputMessages(request)
+            };
+
+            if (!string.IsNullOrWhiteSpace(_groqAiOptions.ReasoningEffort))
+            {
+                payload.Reasoning = new GroqReasoningRequest
+                {
+                    Effort = _groqAiOptions.ReasoningEffort
+                };
+            }
+
+            var requestJson = JsonSerializer.Serialize(payload, SerializerOptions);
+            var response = await client.PostAsync(
+                BuildResponsesEndpoint(),
+                new StringContent(requestJson, Encoding.UTF8, "application/json"));
+            var responseBody = await response.Content.ReadAsStringAsync();
+
+            if (!response.IsSuccessStatusCode)
+            {
+                throw new UserFriendlyException("The AI provider request failed: " + BuildProviderErrorMessage(responseBody, (int)response.StatusCode));
+            }
+
+            return ParseSuccessResponse(responseBody);
+        }
+
+        /// <summary>
+        /// Builds the provider request message list in system-history-user order.
+        /// </summary>
+        private static IReadOnlyList<GroqInputMessage> BuildInputMessages(AiTextGenerationRequest request)
+        {
+            var messages = new List<GroqInputMessage>
+            {
+                BuildMessage("system", request.SystemInstructions)
+            };
+
+            if (request.ConversationHistory != null)
+            {
+                messages.AddRange(request.ConversationHistory.Select(item => BuildMessage(item.Role, item.Content)));
+            }
+
+            messages.Add(BuildMessage("user", request.UserMessage));
+            return messages;
+        }
+
+        /// <summary>
+        /// Builds a single provider input message.
+        /// </summary>
+        private static GroqInputMessage BuildMessage(string role, string text)
+        {
+            return new GroqInputMessage
+            {
+                Role = role,
+                Content = new[]
+                {
+                    new GroqInputContent
+                    {
+                        Type = "input_text",
+                        Text = text
+                    }
+                }
+            };
+        }
+
+        /// <summary>
+        /// Parses the successful provider response into the neutral result shape.
+        /// </summary>
+        private AiTextGenerationResult ParseSuccessResponse(string responseBody)
+        {
+            try
+            {
+                using var document = JsonDocument.Parse(responseBody);
+                var root = document.RootElement;
+                var text = TryReadOutputText(root);
+
+                if (string.IsNullOrWhiteSpace(text))
+                {
+                    throw new UserFriendlyException("The AI provider returned a response without generated text.");
+                }
+
+                return new AiTextGenerationResult
+                {
+                    Text = text.Trim(),
+                    Provider = "groq",
+                    Model = TryReadString(root, "model") ?? _groqAiOptions.Model,
+                    ProviderResponseId = TryReadString(root, "id"),
+                    UsageJson = root.TryGetProperty("usage", out var usageElement) ? usageElement.GetRawText() : null
+                };
+            }
+            catch (JsonException exception)
+            {
+                throw new UserFriendlyException("The AI provider returned an unexpected response payload.", exception);
+            }
+        }
+
+        /// <summary>
+        /// Tries to read the generated output text from the provider payload.
+        /// </summary>
+        private static string TryReadOutputText(JsonElement root)
+        {
+            var directOutputText = TryReadString(root, "output_text");
+            if (!string.IsNullOrWhiteSpace(directOutputText))
+            {
+                return directOutputText;
+            }
+
+            if (!root.TryGetProperty("output", out var outputElement) || outputElement.ValueKind != JsonValueKind.Array)
+            {
+                return null;
+            }
+
+            var textBuilder = new StringBuilder();
+
+            foreach (var outputItem in outputElement.EnumerateArray())
+            {
+                if (!outputItem.TryGetProperty("content", out var contentElement) || contentElement.ValueKind != JsonValueKind.Array)
+                {
+                    continue;
+                }
+
+                foreach (var contentItem in contentElement.EnumerateArray())
+                {
+                    var text = TryReadString(contentItem, "text");
+                    if (!string.IsNullOrWhiteSpace(text))
+                    {
+                        textBuilder.AppendLine(text);
+                    }
+                }
+            }
+
+            return textBuilder.Length == 0 ? null : textBuilder.ToString().Trim();
+        }
+
+        /// <summary>
+        /// Tries to read a string property safely.
+        /// </summary>
+        private static string TryReadString(JsonElement element, string propertyName)
+        {
+            if (!element.TryGetProperty(propertyName, out var propertyElement) || propertyElement.ValueKind != JsonValueKind.String)
+            {
+                return null;
+            }
+
+            return propertyElement.GetString();
+        }
+
+        /// <summary>
+        /// Builds a compact provider error message from the failed response body.
+        /// </summary>
+        private static string BuildProviderErrorMessage(string responseBody, int statusCode)
+        {
+            if (string.IsNullOrWhiteSpace(responseBody))
+            {
+                return "HTTP " + statusCode + ".";
+            }
+
+            var compactBody = responseBody.Length <= 300 ? responseBody : responseBody.Substring(0, 300);
+            return "HTTP " + statusCode + ": " + compactBody;
+        }
+
+        /// <summary>
+        /// Validates the required provider configuration before making a request.
+        /// </summary>
+        private void ValidateConfiguration()
+        {
+            if (string.IsNullOrWhiteSpace(_groqAiOptions.ApiKey))
+            {
+                throw new UserFriendlyException("Groq AI is not configured. Set AI:Groq:ApiKey before using dataset AI generation.");
+            }
+
+            if (string.IsNullOrWhiteSpace(_groqAiOptions.Model))
+            {
+                throw new UserFriendlyException("Groq AI is not configured. Set AI:Groq:Model before using dataset AI generation.");
+            }
+        }
+
+        /// <summary>
+        /// Builds the configured Groq responses endpoint URL.
+        /// </summary>
+        private string BuildResponsesEndpoint()
+        {
+            var baseUrl = string.IsNullOrWhiteSpace(_groqAiOptions.BaseUrl)
+                ? "https://api.groq.com/openai/v1/responses"
+                : _groqAiOptions.BaseUrl.TrimEnd('/');
+
+            return baseUrl.EndsWith("/responses", StringComparison.OrdinalIgnoreCase)
+                ? baseUrl
+                : baseUrl + "/responses";
+        }
+
+        /// <summary>
+        /// Represents the provider request payload.
+        /// </summary>
+        private class GroqResponsesRequest
+        {
+            public string Model { get; set; }
+
+            public IReadOnlyList<GroqInputMessage> Input { get; set; }
+
+            public int MaxOutputTokens { get; set; }
+
+            public GroqReasoningRequest Reasoning { get; set; }
+        }
+
+        /// <summary>
+        /// Represents a provider input message.
+        /// </summary>
+        private class GroqInputMessage
+        {
+            public string Role { get; set; }
+
+            public IReadOnlyList<GroqInputContent> Content { get; set; }
+        }
+
+        /// <summary>
+        /// Represents provider text content.
+        /// </summary>
+        private class GroqInputContent
+        {
+            public string Type { get; set; }
+
+            public string Text { get; set; }
+        }
+
+        /// <summary>
+        /// Represents the optional provider reasoning settings.
+        /// </summary>
+        private class GroqReasoningRequest
+        {
+            public string Effort { get; set; }
+        }
+    }
+}

--- a/aspnet-core/src/AstraLab.Application/Services/AI/IAiConversationHistoryBuilder.cs
+++ b/aspnet-core/src/AstraLab.Application/Services/AI/IAiConversationHistoryBuilder.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+using AstraLab.Core.Domains.AI;
+
+namespace AstraLab.Services.AI
+{
+    /// <summary>
+    /// Builds replayable conversation history from persisted AI responses.
+    /// </summary>
+    public interface IAiConversationHistoryBuilder
+    {
+        /// <summary>
+        /// Builds replayable conversation messages in chronological order.
+        /// </summary>
+        IReadOnlyList<AiConversationHistoryMessage> Build(IReadOnlyList<AIResponse> responses);
+    }
+}

--- a/aspnet-core/src/AstraLab.Application/Services/AI/IAiDatasetContextBuilder.cs
+++ b/aspnet-core/src/AstraLab.Application/Services/AI/IAiDatasetContextBuilder.cs
@@ -1,0 +1,15 @@
+using System.Threading.Tasks;
+
+namespace AstraLab.Services.AI
+{
+    /// <summary>
+    /// Builds structured, size-controlled dataset context for future AI workflows.
+    /// </summary>
+    public interface IAiDatasetContextBuilder
+    {
+        /// <summary>
+        /// Builds the AI dataset context for the specified dataset version and owner scope.
+        /// </summary>
+        Task<AiDatasetContext> BuildAsync(long datasetVersionId, int tenantId, long ownerUserId);
+    }
+}

--- a/aspnet-core/src/AstraLab.Application/Services/AI/IAiDatasetInsightReader.cs
+++ b/aspnet-core/src/AstraLab.Application/Services/AI/IAiDatasetInsightReader.cs
@@ -1,0 +1,15 @@
+using System.Threading.Tasks;
+
+namespace AstraLab.Services.AI
+{
+    /// <summary>
+    /// Loads compact read-only enrichment data for dataset AI prompts.
+    /// </summary>
+    public interface IAiDatasetInsightReader
+    {
+        /// <summary>
+        /// Reads compact enrichment context for the specified dataset version.
+        /// </summary>
+        Task<AiDatasetInsightContext> ReadAsync(long datasetVersionId, int tenantId, long ownerUserId);
+    }
+}

--- a/aspnet-core/src/AstraLab.Application/Services/AI/IAiDatasetResponseGenerator.cs
+++ b/aspnet-core/src/AstraLab.Application/Services/AI/IAiDatasetResponseGenerator.cs
@@ -19,5 +19,14 @@ namespace AstraLab.Services.AI
             long ownerUserId,
             string userQuery = null,
             long? conversationId = null);
+
+        /// <summary>
+        /// Generates and persists a profiling-triggered automatic insight for the selected dataset version.
+        /// </summary>
+        Task<GenerateDatasetAiResponseResult> GenerateAutomaticInsightAsync(
+            long datasetVersionId,
+            long datasetProfileId,
+            int tenantId,
+            long ownerUserId);
     }
 }

--- a/aspnet-core/src/AstraLab.Application/Services/AI/IAiDatasetResponseGenerator.cs
+++ b/aspnet-core/src/AstraLab.Application/Services/AI/IAiDatasetResponseGenerator.cs
@@ -1,0 +1,23 @@
+using System.Threading.Tasks;
+using AstraLab.Core.Domains.AI;
+using AstraLab.Services.AI.Dto;
+
+namespace AstraLab.Services.AI
+{
+    /// <summary>
+    /// Orchestrates grounded dataset AI generation and persistence.
+    /// </summary>
+    public interface IAiDatasetResponseGenerator
+    {
+        /// <summary>
+        /// Generates and persists a dataset-scoped AI response.
+        /// </summary>
+        Task<GenerateDatasetAiResponseResult> GenerateAsync(
+            AIResponseType responseType,
+            long datasetVersionId,
+            int tenantId,
+            long ownerUserId,
+            string userQuery = null,
+            long? conversationId = null);
+    }
+}

--- a/aspnet-core/src/AstraLab.Application/Services/AI/IAiDatasetResponseGenerator.cs
+++ b/aspnet-core/src/AstraLab.Application/Services/AI/IAiDatasetResponseGenerator.cs
@@ -18,7 +18,8 @@ namespace AstraLab.Services.AI
             int tenantId,
             long ownerUserId,
             string userQuery = null,
-            long? conversationId = null);
+            long? conversationId = null,
+            long? mlExperimentId = null);
 
         /// <summary>
         /// Generates and persists a profiling-triggered automatic insight for the selected dataset version.
@@ -26,6 +27,14 @@ namespace AstraLab.Services.AI
         Task<GenerateDatasetAiResponseResult> GenerateAutomaticInsightAsync(
             long datasetVersionId,
             long datasetProfileId,
+            int tenantId,
+            long ownerUserId);
+
+        /// <summary>
+        /// Generates and persists an experiment-completed automatic insight for the selected machine learning experiment.
+        /// </summary>
+        Task<GenerateDatasetAiResponseResult> GenerateAutomaticExperimentInsightAsync(
+            long mlExperimentId,
             int tenantId,
             long ownerUserId);
     }

--- a/aspnet-core/src/AstraLab.Application/Services/AI/IAiMlExperimentContextBuilder.cs
+++ b/aspnet-core/src/AstraLab.Application/Services/AI/IAiMlExperimentContextBuilder.cs
@@ -1,0 +1,15 @@
+using System.Threading.Tasks;
+
+namespace AstraLab.Services.AI
+{
+    /// <summary>
+    /// Builds structured machine learning experiment context for grounded AI workflows.
+    /// </summary>
+    public interface IAiMlExperimentContextBuilder
+    {
+        /// <summary>
+        /// Builds the machine learning experiment context for the selected owner-scoped experiment.
+        /// </summary>
+        Task<AiMlExperimentContext> BuildAsync(long mlExperimentId, int tenantId, long ownerUserId);
+    }
+}

--- a/aspnet-core/src/AstraLab.Application/Services/AI/IAiPromptBuilder.cs
+++ b/aspnet-core/src/AstraLab.Application/Services/AI/IAiPromptBuilder.cs
@@ -1,0 +1,15 @@
+using AstraLab.Core.Domains.AI;
+
+namespace AstraLab.Services.AI
+{
+    /// <summary>
+    /// Builds deterministic task-specific prompts for dataset AI workflows.
+    /// </summary>
+    public interface IAiPromptBuilder
+    {
+        /// <summary>
+        /// Builds a prompt payload for the requested dataset AI task.
+        /// </summary>
+        AiPromptBuildResult Build(AiPromptBuildRequest request);
+    }
+}

--- a/aspnet-core/src/AstraLab.Application/Services/AI/IAiTextGenerationClient.cs
+++ b/aspnet-core/src/AstraLab.Application/Services/AI/IAiTextGenerationClient.cs
@@ -1,0 +1,15 @@
+using System.Threading.Tasks;
+
+namespace AstraLab.Services.AI
+{
+    /// <summary>
+    /// Sends prompt payloads to a text-generation provider.
+    /// </summary>
+    public interface IAiTextGenerationClient
+    {
+        /// <summary>
+        /// Generates text for the supplied request.
+        /// </summary>
+        Task<AiTextGenerationResult> GenerateTextAsync(AiTextGenerationRequest request);
+    }
+}

--- a/aspnet-core/src/AstraLab.Application/Services/AI/IDatasetAiAppService.cs
+++ b/aspnet-core/src/AstraLab.Application/Services/AI/IDatasetAiAppService.cs
@@ -1,0 +1,33 @@
+using System.Threading.Tasks;
+using Abp.Application.Services;
+using Abp.Application.Services.Dto;
+using AstraLab.Services.AI.Dto;
+
+namespace AstraLab.Services.AI
+{
+    /// <summary>
+    /// Exposes dataset-scoped AI generation workflows for summaries, insights, recommendations, and Q&amp;A.
+    /// </summary>
+    public interface IDatasetAiAppService : IApplicationService
+    {
+        /// <summary>
+        /// Generates a concise summary for the selected dataset version.
+        /// </summary>
+        Task<GenerateDatasetAiResponseResult> GenerateSummaryAsync(EntityDto<long> datasetVersionId);
+
+        /// <summary>
+        /// Generates concise data-quality insights for the selected dataset version.
+        /// </summary>
+        Task<GenerateDatasetAiResponseResult> GenerateInsightsAsync(EntityDto<long> datasetVersionId);
+
+        /// <summary>
+        /// Generates cleaning and transformation recommendations for the selected dataset version.
+        /// </summary>
+        Task<GenerateDatasetAiResponseResult> GenerateCleaningRecommendationsAsync(EntityDto<long> datasetVersionId);
+
+        /// <summary>
+        /// Answers a grounded natural-language question about the selected dataset version.
+        /// </summary>
+        Task<GenerateDatasetAiResponseResult> AskAsync(AskDatasetAiQuestionRequest input);
+    }
+}

--- a/aspnet-core/src/AstraLab.Application/Services/AI/IDatasetAiAppService.cs
+++ b/aspnet-core/src/AstraLab.Application/Services/AI/IDatasetAiAppService.cs
@@ -26,9 +26,24 @@ namespace AstraLab.Services.AI
         Task<GenerateDatasetAiResponseResult> GenerateCleaningRecommendationsAsync(EntityDto<long> datasetVersionId);
 
         /// <summary>
+        /// Generates a concise summary for the selected machine learning experiment.
+        /// </summary>
+        Task<GenerateDatasetAiResponseResult> GenerateExperimentSummaryAsync(EntityDto<long> mlExperimentId);
+
+        /// <summary>
+        /// Generates concise next-step recommendations for the selected machine learning experiment.
+        /// </summary>
+        Task<GenerateDatasetAiResponseResult> GenerateExperimentRecommendationsAsync(EntityDto<long> mlExperimentId);
+
+        /// <summary>
         /// Answers a grounded natural-language question about the selected dataset version.
         /// </summary>
         Task<GenerateDatasetAiResponseResult> AskAsync(AskDatasetAiQuestionRequest input);
+
+        /// <summary>
+        /// Answers a grounded natural-language question about the selected machine learning experiment.
+        /// </summary>
+        Task<GenerateDatasetAiResponseResult> AskExperimentAsync(AskExperimentAiQuestionRequest input);
 
         /// <summary>
         /// Gets a persisted AI conversation summary for the selected conversation.
@@ -49,5 +64,10 @@ namespace AstraLab.Services.AI
         /// Gets the latest persisted profiling-triggered automatic insight for the selected dataset version.
         /// </summary>
         Task<AIResponseDto> GetLatestAutomaticInsightAsync(EntityDto<long> datasetVersionId);
+
+        /// <summary>
+        /// Gets the latest persisted experiment-completed automatic insight for the selected machine learning experiment.
+        /// </summary>
+        Task<AIResponseDto> GetLatestAutomaticExperimentInsightAsync(EntityDto<long> mlExperimentId);
     }
 }

--- a/aspnet-core/src/AstraLab.Application/Services/AI/IDatasetAiAppService.cs
+++ b/aspnet-core/src/AstraLab.Application/Services/AI/IDatasetAiAppService.cs
@@ -29,5 +29,25 @@ namespace AstraLab.Services.AI
         /// Answers a grounded natural-language question about the selected dataset version.
         /// </summary>
         Task<GenerateDatasetAiResponseResult> AskAsync(AskDatasetAiQuestionRequest input);
+
+        /// <summary>
+        /// Gets a persisted AI conversation summary for the selected conversation.
+        /// </summary>
+        Task<AIConversationDto> GetConversationAsync(EntityDto<long> conversationId);
+
+        /// <summary>
+        /// Gets persisted AI conversations for the selected dataset or dataset version.
+        /// </summary>
+        Task<PagedResultDto<AIConversationDto>> GetConversationsAsync(GetDatasetAiConversationsRequest input);
+
+        /// <summary>
+        /// Gets persisted AI responses for the selected conversation thread.
+        /// </summary>
+        Task<PagedResultDto<AIResponseDto>> GetResponsesAsync(GetDatasetAiResponsesRequest input);
+
+        /// <summary>
+        /// Gets the latest persisted profiling-triggered automatic insight for the selected dataset version.
+        /// </summary>
+        Task<AIResponseDto> GetLatestAutomaticInsightAsync(EntityDto<long> datasetVersionId);
     }
 }

--- a/aspnet-core/src/AstraLab.Application/Services/Datasets/DatasetProfilingManager.cs
+++ b/aspnet-core/src/AstraLab.Application/Services/Datasets/DatasetProfilingManager.cs
@@ -1,9 +1,11 @@
 using System.Linq;
 using System.Threading.Tasks;
+using Abp.BackgroundJobs;
 using Abp.Dependency;
 using Abp.Domain.Repositories;
 using Abp.Runtime.Session;
 using Abp.UI;
+using AstraLab.Services.AI;
 using AstraLab.Core.Domains.Datasets;
 using AstraLab.Services.Datasets.Dto;
 using AstraLab.Services.Datasets.Profiling;
@@ -24,6 +26,7 @@ namespace AstraLab.Services.Datasets
         private readonly IDatasetOwnershipAccessChecker _datasetOwnershipAccessChecker;
         private readonly IRawDatasetStorage _rawDatasetStorage;
         private readonly IDatasetProfiler _datasetProfiler;
+        private readonly IBackgroundJobManager _backgroundJobManager;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DatasetProfilingManager"/> class.
@@ -35,7 +38,8 @@ namespace AstraLab.Services.Datasets
             IRepository<DatasetColumnProfile, long> datasetColumnProfileRepository,
             IDatasetOwnershipAccessChecker datasetOwnershipAccessChecker,
             IRawDatasetStorage rawDatasetStorage,
-            IDatasetProfiler datasetProfiler)
+            IDatasetProfiler datasetProfiler,
+            IBackgroundJobManager backgroundJobManager)
         {
             _datasetRepository = datasetRepository;
             _datasetColumnRepository = datasetColumnRepository;
@@ -44,6 +48,7 @@ namespace AstraLab.Services.Datasets
             _datasetOwnershipAccessChecker = datasetOwnershipAccessChecker;
             _rawDatasetStorage = rawDatasetStorage;
             _datasetProfiler = datasetProfiler;
+            _backgroundJobManager = backgroundJobManager;
         }
 
         /// <summary>
@@ -93,12 +98,13 @@ namespace AstraLab.Services.Datasets
                     });
                 }
 
-                await ReplaceCurrentProfileSnapshotAsync(tenantId, datasetVersion, datasetColumns, profilingResult);
+                var datasetProfileId = await ReplaceCurrentProfileSnapshotAsync(tenantId, datasetVersion, datasetColumns, profilingResult);
 
                 dataset.Status = DatasetStatus.Ready;
                 datasetVersion.Status = DatasetVersionStatus.Active;
                 datasetVersion.RowCount = ToIntValue(profilingResult.RowCount);
                 await CurrentUnitOfWork.SaveChangesAsync();
+                await TryEnqueueAutomaticInsightJobAsync(datasetVersion.Id, datasetProfileId, tenantId, ownerUserId);
 
                 return await BuildDatasetProfileDtoAsync(datasetVersion.Id, tenantId);
             }
@@ -124,7 +130,7 @@ namespace AstraLab.Services.Datasets
         /// <summary>
         /// Replaces the current persisted profiling snapshot and synchronizes legacy summary fields.
         /// </summary>
-        private async Task ReplaceCurrentProfileSnapshotAsync(
+        private async Task<long> ReplaceCurrentProfileSnapshotAsync(
             int tenantId,
             DatasetVersion datasetVersion,
             System.Collections.Generic.IReadOnlyList<DatasetColumn> datasetColumns,
@@ -187,6 +193,8 @@ namespace AstraLab.Services.Datasets
                     StatisticsJson = profiledColumn.StatisticsJson
                 });
             }
+
+            return datasetProfile.Id;
         }
 
         private async Task<DatasetProfileDto> BuildDatasetProfileDtoAsync(long datasetVersionId, int tenantId)
@@ -231,6 +239,32 @@ namespace AstraLab.Services.Datasets
         private static int ToIntValue(long value)
         {
             return value > int.MaxValue ? int.MaxValue : (int)value;
+        }
+
+        /// <summary>
+        /// Enqueues best-effort automatic AI insight generation without blocking profiling success.
+        /// </summary>
+        private async Task TryEnqueueAutomaticInsightJobAsync(
+            long datasetVersionId,
+            long datasetProfileId,
+            int tenantId,
+            long ownerUserId)
+        {
+            try
+            {
+                await _backgroundJobManager.EnqueueAsync<GenerateAutomaticDatasetInsightJob, GenerateAutomaticDatasetInsightJobArgs>(
+                    new GenerateAutomaticDatasetInsightJobArgs
+                    {
+                        DatasetVersionId = datasetVersionId,
+                        DatasetProfileId = datasetProfileId,
+                        TenantId = tenantId,
+                        OwnerUserId = ownerUserId
+                    });
+            }
+            catch (System.Exception exception)
+            {
+                Logger.Warn("Automatic dataset insight job enqueue failed after profiling completed.", exception);
+            }
         }
     }
 }

--- a/aspnet-core/src/AstraLab.Application/Services/ML/MLExperimentExecutionManager.cs
+++ b/aspnet-core/src/AstraLab.Application/Services/ML/MLExperimentExecutionManager.cs
@@ -1,11 +1,13 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using Abp.BackgroundJobs;
 using Abp.Dependency;
 using Abp.Domain.Repositories;
 using Abp.UI;
 using AstraLab.Core.Domains.Datasets;
 using AstraLab.Core.Domains.ML;
+using AstraLab.Services.AI;
 using AstraLab.Services.ML.Dto;
 using Microsoft.EntityFrameworkCore;
 
@@ -21,6 +23,7 @@ namespace AstraLab.Services.ML
         private readonly IRepository<MLModelMetric, long> _mlModelMetricRepository;
         private readonly IRepository<MLModelFeatureImportance, long> _mlModelFeatureImportanceRepository;
         private readonly IRepository<DatasetColumn, long> _datasetColumnRepository;
+        private readonly IBackgroundJobManager _backgroundJobManager;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MLExperimentExecutionManager"/> class.
@@ -30,13 +33,15 @@ namespace AstraLab.Services.ML
             IRepository<MLModel, long> mlModelRepository,
             IRepository<MLModelMetric, long> mlModelMetricRepository,
             IRepository<MLModelFeatureImportance, long> mlModelFeatureImportanceRepository,
-            IRepository<DatasetColumn, long> datasetColumnRepository)
+            IRepository<DatasetColumn, long> datasetColumnRepository,
+            IBackgroundJobManager backgroundJobManager)
         {
             _mlExperimentRepository = mlExperimentRepository;
             _mlModelRepository = mlModelRepository;
             _mlModelMetricRepository = mlModelMetricRepository;
             _mlModelFeatureImportanceRepository = mlModelFeatureImportanceRepository;
             _datasetColumnRepository = datasetColumnRepository;
+            _backgroundJobManager = backgroundJobManager;
         }
 
         /// <summary>
@@ -47,6 +52,8 @@ namespace AstraLab.Services.ML
             ValidateCompletionRequest(input);
 
             var experiment = await _mlExperimentRepository.GetAll()
+                .Include(item => item.DatasetVersion)
+                    .ThenInclude(item => item.Dataset)
                 .Include(item => item.Model)
                     .ThenInclude(item => item.Metrics)
                 .Include(item => item.Model)
@@ -121,6 +128,7 @@ namespace AstraLab.Services.ML
             experiment.WarningsJson = input.WarningsJson;
 
             await CurrentUnitOfWork.SaveChangesAsync();
+            await TryEnqueueAutomaticInsightJobAsync(experiment);
         }
 
         /// <summary>
@@ -217,6 +225,33 @@ namespace AstraLab.Services.ML
             if (string.IsNullOrWhiteSpace(input.FailureMessage))
             {
                 throw new UserFriendlyException("A failure message is required when an ML experiment fails.");
+            }
+        }
+
+        /// <summary>
+        /// Enqueues best-effort automatic AI insight generation without blocking ML completion success.
+        /// </summary>
+        private async Task TryEnqueueAutomaticInsightJobAsync(MLExperiment experiment)
+        {
+            if (experiment.Status != MLExperimentStatus.Completed || experiment.Model == null)
+            {
+                return;
+            }
+
+            try
+            {
+                await _backgroundJobManager.EnqueueAsync<GenerateAutomaticExperimentInsightJob, GenerateAutomaticExperimentInsightJobArgs>(
+                    new GenerateAutomaticExperimentInsightJobArgs
+                    {
+                        MLExperimentId = experiment.Id,
+                        DatasetVersionId = experiment.DatasetVersionId,
+                        TenantId = experiment.TenantId,
+                        OwnerUserId = experiment.DatasetVersion.Dataset.OwnerUserId
+                    });
+            }
+            catch (Exception exception)
+            {
+                Logger.Warn("Automatic ML experiment insight job enqueue failed after experiment completion.", exception);
             }
         }
     }

--- a/aspnet-core/src/AstraLab.Core/Domains/AI/AIConversation.cs
+++ b/aspnet-core/src/AstraLab.Core/Domains/AI/AIConversation.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+using Abp.Domain.Entities;
+using Abp.Domain.Entities.Auditing;
+using AstraLab.Core.Domains.Datasets;
+
+namespace AstraLab.Core.Domains.AI
+{
+    /// <summary>
+    /// Represents a tenant-scoped dataset conversation thread that groups related AI responses.
+    /// </summary>
+    public class AIConversation : FullAuditedEntity<long>, IMustHaveTenant
+    {
+        /// <summary>
+        /// Gets or sets the tenant that owns the conversation thread.
+        /// </summary>
+        public int TenantId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the dataset identifier that scopes the conversation.
+        /// </summary>
+        public long DatasetId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the dataset that scopes the conversation.
+        /// </summary>
+        public Dataset Dataset { get; set; }
+
+        /// <summary>
+        /// Gets or sets the owning user identifier for the conversation.
+        /// </summary>
+        public long OwnerUserId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the timestamp of the latest persisted interaction in the thread.
+        /// </summary>
+        public DateTime LastInteractionTime { get; set; }
+
+        /// <summary>
+        /// Gets or sets the persisted responses recorded for the conversation.
+        /// </summary>
+        public ICollection<AIResponse> Responses { get; set; } = new List<AIResponse>();
+    }
+}

--- a/aspnet-core/src/AstraLab.Core/Domains/AI/AIResponse.cs
+++ b/aspnet-core/src/AstraLab.Core/Domains/AI/AIResponse.cs
@@ -1,0 +1,82 @@
+using Abp.Domain.Entities;
+using Abp.Domain.Entities.Auditing;
+using AstraLab.Core.Domains.Datasets;
+
+namespace AstraLab.Core.Domains.AI
+{
+    /// <summary>
+    /// Represents a persisted assistant response tied to a dataset version and conversation thread.
+    /// </summary>
+    public class AIResponse : FullAuditedEntity<long>, IMustHaveTenant
+    {
+        /// <summary>
+        /// The database column type used for persisted user queries.
+        /// </summary>
+        public const string UserQueryColumnType = "text";
+
+        /// <summary>
+        /// The database column type used for persisted AI response content.
+        /// </summary>
+        public const string ResponseContentColumnType = "text";
+
+        /// <summary>
+        /// The database column type used for serialized metadata payloads.
+        /// </summary>
+        public const string MetadataJsonColumnType = "text";
+
+        /// <summary>
+        /// Gets or sets the tenant that owns the response.
+        /// </summary>
+        public int TenantId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the conversation identifier that groups this response.
+        /// </summary>
+        public long AIConversationId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the conversation that groups this response.
+        /// </summary>
+        public AIConversation AIConversation { get; set; }
+
+        /// <summary>
+        /// Gets or sets the dataset version identifier that grounds this response.
+        /// </summary>
+        public long DatasetVersionId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the dataset version that grounds this response.
+        /// </summary>
+        public DatasetVersion DatasetVersion { get; set; }
+
+        /// <summary>
+        /// Gets or sets the optional user query that led to this response.
+        /// </summary>
+        public string UserQuery { get; set; }
+
+        /// <summary>
+        /// Gets or sets the persisted AI-generated response content.
+        /// </summary>
+        public string ResponseContent { get; set; }
+
+        /// <summary>
+        /// Gets or sets the response type used to classify this persisted response.
+        /// </summary>
+        public AIResponseType ResponseType { get; set; }
+
+        /// <summary>
+        /// Gets or sets the optional linked dataset transformation identifier.
+        /// </summary>
+        public long? DatasetTransformationId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the optional linked dataset transformation.
+        /// </summary>
+        public DatasetTransformation DatasetTransformation { get; set; }
+
+        /// <summary>
+        /// Gets or sets the optional serialized metadata payload for future extensibility.
+        /// </summary>
+        public string MetadataJson { get; set; }
+    }
+}

--- a/aspnet-core/src/AstraLab.Core/Domains/AI/AIResponse.cs
+++ b/aspnet-core/src/AstraLab.Core/Domains/AI/AIResponse.cs
@@ -1,6 +1,7 @@
 using Abp.Domain.Entities;
 using Abp.Domain.Entities.Auditing;
 using AstraLab.Core.Domains.Datasets;
+using AstraLab.Core.Domains.ML;
 
 namespace AstraLab.Core.Domains.AI
 {
@@ -73,6 +74,16 @@ namespace AstraLab.Core.Domains.AI
         /// Gets or sets the optional linked dataset transformation.
         /// </summary>
         public DatasetTransformation DatasetTransformation { get; set; }
+
+        /// <summary>
+        /// Gets or sets the optional linked machine learning experiment identifier.
+        /// </summary>
+        public long? MLExperimentId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the optional linked machine learning experiment.
+        /// </summary>
+        public MLExperiment MLExperiment { get; set; }
 
         /// <summary>
         /// Gets or sets the optional serialized metadata payload for future extensibility.

--- a/aspnet-core/src/AstraLab.Core/Domains/AI/AIResponseType.cs
+++ b/aspnet-core/src/AstraLab.Core/Domains/AI/AIResponseType.cs
@@ -1,0 +1,35 @@
+using System;
+
+namespace AstraLab.Core.Domains.AI
+{
+    /// <summary>
+    /// Defines the persisted assistant response categories supported by the platform.
+    /// </summary>
+    public enum AIResponseType
+    {
+        /// <summary>
+        /// A high-level dataset or dataset-version summary response.
+        /// </summary>
+        Summary = 1,
+
+        /// <summary>
+        /// A recommendation response, such as suggested cleaning or transformation actions.
+        /// </summary>
+        Recommendation = 2,
+
+        /// <summary>
+        /// An explanatory response that clarifies a concept, result, or dataset behavior.
+        /// </summary>
+        Explanation = 3,
+
+        /// <summary>
+        /// A generated insight response that highlights notable patterns or findings.
+        /// </summary>
+        Insight = 4,
+
+        /// <summary>
+        /// A question-and-answer response grounded in the selected dataset context.
+        /// </summary>
+        QuestionAnswer = 5
+    }
+}

--- a/aspnet-core/src/AstraLab.Core/Domains/Datasets/Dataset.cs
+++ b/aspnet-core/src/AstraLab.Core/Domains/Datasets/Dataset.cs
@@ -1,5 +1,6 @@
 using Abp.Domain.Entities;
 using Abp.Domain.Entities.Auditing;
+using AstraLab.Core.Domains.AI;
 using System.Collections.Generic;
 
 namespace AstraLab.Core.Domains.Datasets
@@ -73,5 +74,10 @@ namespace AstraLab.Core.Domains.Datasets
         /// Gets or sets all versions recorded for the dataset.
         /// </summary>
         public ICollection<DatasetVersion> Versions { get; set; } = new List<DatasetVersion>();
+
+        /// <summary>
+        /// Gets or sets the persisted AI conversations scoped to the dataset.
+        /// </summary>
+        public ICollection<AIConversation> AIConversations { get; set; } = new List<AIConversation>();
     }
 }

--- a/aspnet-core/src/AstraLab.Core/Domains/Datasets/DatasetTransformation.cs
+++ b/aspnet-core/src/AstraLab.Core/Domains/Datasets/DatasetTransformation.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Collections.Generic;
 using Abp.Domain.Entities;
 using Abp.Domain.Entities.Auditing;
+using AstraLab.Core.Domains.AI;
 
 namespace AstraLab.Core.Domains.Datasets
 {
@@ -68,5 +70,10 @@ namespace AstraLab.Core.Domains.Datasets
         /// Gets or sets the serialized summary payload when extra execution notes are available.
         /// </summary>
         public string SummaryJson { get; set; }
+
+        /// <summary>
+        /// Gets or sets the persisted AI responses optionally linked to this transformation.
+        /// </summary>
+        public ICollection<AIResponse> AIResponses { get; set; } = new List<AIResponse>();
     }
 }

--- a/aspnet-core/src/AstraLab.Core/Domains/Datasets/DatasetVersion.cs
+++ b/aspnet-core/src/AstraLab.Core/Domains/Datasets/DatasetVersion.cs
@@ -1,6 +1,7 @@
 using Abp.Domain.Entities;
 using Abp.Domain.Entities.Auditing;
 using System.Collections.Generic;
+using AstraLab.Core.Domains.AI;
 using AstraLab.Core.Domains.ML;
 
 namespace AstraLab.Core.Domains.Datasets
@@ -99,5 +100,10 @@ namespace AstraLab.Core.Domains.Datasets
         /// Gets or sets the persisted machine learning experiment runs for this dataset version.
         /// </summary>
         public ICollection<MLExperiment> MlExperiments { get; set; } = new List<MLExperiment>();
+
+        /// <summary>
+        /// Gets or sets the persisted AI responses grounded in this dataset version.
+        /// </summary>
+        public ICollection<AIResponse> AIResponses { get; set; } = new List<AIResponse>();
     }
 }

--- a/aspnet-core/src/AstraLab.Core/Domains/ML/MLExperiment.cs
+++ b/aspnet-core/src/AstraLab.Core/Domains/ML/MLExperiment.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using Abp.Domain.Entities;
 using Abp.Domain.Entities.Auditing;
+using AstraLab.Core.Domains.AI;
 using AstraLab.Core.Domains.Datasets;
 
 namespace AstraLab.Core.Domains.ML
@@ -120,5 +121,10 @@ namespace AstraLab.Core.Domains.ML
         /// Gets or sets the optional trained model output for the experiment.
         /// </summary>
         public MLModel Model { get; set; }
+
+        /// <summary>
+        /// Gets or sets the persisted AI responses optionally linked to this experiment.
+        /// </summary>
+        public ICollection<AIResponse> AIResponses { get; set; } = new List<AIResponse>();
     }
 }

--- a/aspnet-core/src/AstraLab.EntityFrameworkCore/EntityFrameworkCore/AstraLabDbContext.cs
+++ b/aspnet-core/src/AstraLab.EntityFrameworkCore/EntityFrameworkCore/AstraLabDbContext.cs
@@ -2,6 +2,7 @@
 using Abp.Zero.EntityFrameworkCore;
 using AstraLab.Authorization.Roles;
 using AstraLab.Authorization.Users;
+using AstraLab.Core.Domains.AI;
 using AstraLab.Core.Domains.Datasets;
 using AstraLab.Core.Domains.ML;
 using AstraLab.MultiTenancy;
@@ -46,6 +47,16 @@ namespace AstraLab.EntityFrameworkCore
         /// Gets or sets the persisted transformation history rows for dataset version processing.
         /// </summary>
         public DbSet<DatasetTransformation> DatasetTransformations { get; set; }
+
+        /// <summary>
+        /// Gets or sets the persisted AI conversation threads.
+        /// </summary>
+        public DbSet<AIConversation> AIConversations { get; set; }
+
+        /// <summary>
+        /// Gets or sets the persisted AI responses.
+        /// </summary>
+        public DbSet<AIResponse> AIResponses { get; set; }
 
         /// <summary>
         /// Gets or sets the persisted machine learning experiment runs.
@@ -268,6 +279,66 @@ namespace AstraLab.EntityFrameworkCore
                     .IsUnique();
 
                 entity.HasIndex(datasetTransformation => new { datasetTransformation.TenantId, datasetTransformation.ExecutedAt });
+            });
+
+            modelBuilder.Entity<AIConversation>(entity =>
+            {
+                entity.ToTable("AIConversations");
+
+                entity.HasOne(aiConversation => aiConversation.Dataset)
+                    .WithMany(dataset => dataset.AIConversations)
+                    .HasForeignKey(aiConversation => aiConversation.DatasetId)
+                    .OnDelete(DeleteBehavior.Cascade);
+
+                entity.HasIndex(aiConversation => new
+                {
+                    aiConversation.TenantId,
+                    aiConversation.DatasetId,
+                    aiConversation.OwnerUserId,
+                    aiConversation.LastInteractionTime
+                });
+            });
+
+            modelBuilder.Entity<AIResponse>(entity =>
+            {
+                entity.ToTable("AIResponses");
+
+                entity.Property(aiResponse => aiResponse.UserQuery)
+                    .HasColumnType(AIResponse.UserQueryColumnType);
+
+                entity.Property(aiResponse => aiResponse.ResponseContent)
+                    .IsRequired()
+                    .HasColumnType(AIResponse.ResponseContentColumnType);
+
+                entity.Property(aiResponse => aiResponse.MetadataJson)
+                    .HasColumnType(AIResponse.MetadataJsonColumnType);
+
+                entity.HasOne(aiResponse => aiResponse.AIConversation)
+                    .WithMany(aiConversation => aiConversation.Responses)
+                    .HasForeignKey(aiResponse => aiResponse.AIConversationId)
+                    .OnDelete(DeleteBehavior.Cascade);
+
+                entity.HasOne(aiResponse => aiResponse.DatasetVersion)
+                    .WithMany(datasetVersion => datasetVersion.AIResponses)
+                    .HasForeignKey(aiResponse => aiResponse.DatasetVersionId)
+                    .OnDelete(DeleteBehavior.Cascade);
+
+                entity.HasOne(aiResponse => aiResponse.DatasetTransformation)
+                    .WithMany(datasetTransformation => datasetTransformation.AIResponses)
+                    .HasForeignKey(aiResponse => aiResponse.DatasetTransformationId)
+                    .OnDelete(DeleteBehavior.Restrict);
+
+                entity.HasIndex(aiResponse => new { aiResponse.AIConversationId, aiResponse.CreationTime });
+
+                entity.HasIndex(aiResponse => new
+                {
+                    aiResponse.TenantId,
+                    aiResponse.DatasetVersionId,
+                    aiResponse.ResponseType,
+                    aiResponse.CreationTime
+                });
+
+                entity.HasIndex(aiResponse => aiResponse.DatasetTransformationId);
             });
 
             modelBuilder.Entity<MLExperiment>(entity =>

--- a/aspnet-core/src/AstraLab.EntityFrameworkCore/EntityFrameworkCore/AstraLabDbContext.cs
+++ b/aspnet-core/src/AstraLab.EntityFrameworkCore/EntityFrameworkCore/AstraLabDbContext.cs
@@ -328,6 +328,11 @@ namespace AstraLab.EntityFrameworkCore
                     .HasForeignKey(aiResponse => aiResponse.DatasetTransformationId)
                     .OnDelete(DeleteBehavior.Restrict);
 
+                entity.HasOne(aiResponse => aiResponse.MLExperiment)
+                    .WithMany(mlExperiment => mlExperiment.AIResponses)
+                    .HasForeignKey(aiResponse => aiResponse.MLExperimentId)
+                    .OnDelete(DeleteBehavior.Restrict);
+
                 entity.HasIndex(aiResponse => new { aiResponse.AIConversationId, aiResponse.CreationTime });
 
                 entity.HasIndex(aiResponse => new
@@ -339,6 +344,7 @@ namespace AstraLab.EntityFrameworkCore
                 });
 
                 entity.HasIndex(aiResponse => aiResponse.DatasetTransformationId);
+                entity.HasIndex(aiResponse => aiResponse.MLExperimentId);
             });
 
             modelBuilder.Entity<MLExperiment>(entity =>

--- a/aspnet-core/src/AstraLab.EntityFrameworkCore/Migrations/20260402070806_AddAiResponsePersistenceFoundation.Designer.cs
+++ b/aspnet-core/src/AstraLab.EntityFrameworkCore/Migrations/20260402070806_AddAiResponsePersistenceFoundation.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using AstraLab.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace AstraLab.Migrations
 {
     [DbContext(typeof(AstraLabDbContext))]
-    partial class AstraLabDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260402070806_AddAiResponsePersistenceFoundation")]
+    partial class AddAiResponsePersistenceFoundation
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/aspnet-core/src/AstraLab.EntityFrameworkCore/Migrations/20260402070806_AddAiResponsePersistenceFoundation.cs
+++ b/aspnet-core/src/AstraLab.EntityFrameworkCore/Migrations/20260402070806_AddAiResponsePersistenceFoundation.cs
@@ -1,0 +1,130 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace AstraLab.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAiResponsePersistenceFoundation : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "AIConversations",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "bigint", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    TenantId = table.Column<int>(type: "integer", nullable: false),
+                    DatasetId = table.Column<long>(type: "bigint", nullable: false),
+                    OwnerUserId = table.Column<long>(type: "bigint", nullable: false),
+                    LastInteractionTime = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CreationTime = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CreatorUserId = table.Column<long>(type: "bigint", nullable: true),
+                    LastModificationTime = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    LastModifierUserId = table.Column<long>(type: "bigint", nullable: true),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false),
+                    DeleterUserId = table.Column<long>(type: "bigint", nullable: true),
+                    DeletionTime = table.Column<DateTime>(type: "timestamp with time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AIConversations", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_AIConversations_Datasets_DatasetId",
+                        column: x => x.DatasetId,
+                        principalTable: "Datasets",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "AIResponses",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "bigint", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    TenantId = table.Column<int>(type: "integer", nullable: false),
+                    AIConversationId = table.Column<long>(type: "bigint", nullable: false),
+                    DatasetVersionId = table.Column<long>(type: "bigint", nullable: false),
+                    UserQuery = table.Column<string>(type: "text", nullable: true),
+                    ResponseContent = table.Column<string>(type: "text", nullable: false),
+                    ResponseType = table.Column<int>(type: "integer", nullable: false),
+                    DatasetTransformationId = table.Column<long>(type: "bigint", nullable: true),
+                    MetadataJson = table.Column<string>(type: "text", nullable: true),
+                    CreationTime = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CreatorUserId = table.Column<long>(type: "bigint", nullable: true),
+                    LastModificationTime = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    LastModifierUserId = table.Column<long>(type: "bigint", nullable: true),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false),
+                    DeleterUserId = table.Column<long>(type: "bigint", nullable: true),
+                    DeletionTime = table.Column<DateTime>(type: "timestamp with time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AIResponses", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_AIResponses_AIConversations_AIConversationId",
+                        column: x => x.AIConversationId,
+                        principalTable: "AIConversations",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_AIResponses_DatasetTransformations_DatasetTransformationId",
+                        column: x => x.DatasetTransformationId,
+                        principalTable: "DatasetTransformations",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_AIResponses_DatasetVersions_DatasetVersionId",
+                        column: x => x.DatasetVersionId,
+                        principalTable: "DatasetVersions",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AIConversations_DatasetId",
+                table: "AIConversations",
+                column: "DatasetId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AIConversations_TenantId_DatasetId_OwnerUserId_LastInteract~",
+                table: "AIConversations",
+                columns: new[] { "TenantId", "DatasetId", "OwnerUserId", "LastInteractionTime" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AIResponses_AIConversationId_CreationTime",
+                table: "AIResponses",
+                columns: new[] { "AIConversationId", "CreationTime" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AIResponses_DatasetTransformationId",
+                table: "AIResponses",
+                column: "DatasetTransformationId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AIResponses_DatasetVersionId",
+                table: "AIResponses",
+                column: "DatasetVersionId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AIResponses_TenantId_DatasetVersionId_ResponseType_Creation~",
+                table: "AIResponses",
+                columns: new[] { "TenantId", "DatasetVersionId", "ResponseType", "CreationTime" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "AIResponses");
+
+            migrationBuilder.DropTable(
+                name: "AIConversations");
+        }
+    }
+}

--- a/aspnet-core/src/AstraLab.EntityFrameworkCore/Migrations/20260402094155_AddAiResponseMlExperimentLinkage.Designer.cs
+++ b/aspnet-core/src/AstraLab.EntityFrameworkCore/Migrations/20260402094155_AddAiResponseMlExperimentLinkage.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using AstraLab.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace AstraLab.Migrations
 {
     [DbContext(typeof(AstraLabDbContext))]
-    partial class AstraLabDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260402094155_AddAiResponseMlExperimentLinkage")]
+    partial class AddAiResponseMlExperimentLinkage
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/aspnet-core/src/AstraLab.EntityFrameworkCore/Migrations/20260402094155_AddAiResponseMlExperimentLinkage.cs
+++ b/aspnet-core/src/AstraLab.EntityFrameworkCore/Migrations/20260402094155_AddAiResponseMlExperimentLinkage.cs
@@ -1,0 +1,49 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AstraLab.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAiResponseMlExperimentLinkage : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<long>(
+                name: "MLExperimentId",
+                table: "AIResponses",
+                type: "bigint",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AIResponses_MLExperimentId",
+                table: "AIResponses",
+                column: "MLExperimentId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_AIResponses_MLExperiments_MLExperimentId",
+                table: "AIResponses",
+                column: "MLExperimentId",
+                principalTable: "MLExperiments",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_AIResponses_MLExperiments_MLExperimentId",
+                table: "AIResponses");
+
+            migrationBuilder.DropIndex(
+                name: "IX_AIResponses_MLExperimentId",
+                table: "AIResponses");
+
+            migrationBuilder.DropColumn(
+                name: "MLExperimentId",
+                table: "AIResponses");
+        }
+    }
+}

--- a/aspnet-core/src/AstraLab.Web.Core/AstraLabWebCoreModule.cs
+++ b/aspnet-core/src/AstraLab.Web.Core/AstraLabWebCoreModule.cs
@@ -14,6 +14,7 @@ using AstraLab.Authentication.JwtBearer;
 using AstraLab.Configuration;
 using AstraLab.EntityFrameworkCore;
 using AstraLab.Services.Datasets.Storage;
+using AstraLab.Services.AI;
 using AstraLab.Services.ML;
 using AstraLab.Services.ML.Storage;
 using AstraLab.Services.Storage;
@@ -58,6 +59,7 @@ namespace AstraLab
 
             RegisterDatasetStorage();
             RegisterMlExecution();
+            RegisterAiGeneration();
             ConfigureTokenAuth();
         }
 
@@ -167,6 +169,22 @@ namespace AstraLab
                 Component.For<IMLJobDispatcher>()
                     .ImplementedBy<MLHttpJobDispatcher>()
                     .LifestyleTransient());
+        }
+
+        private void RegisterAiGeneration()
+        {
+            IocManager.IocContainer.Register(
+                Component.For<GroqAiOptions>()
+                    .Instance(new GroqAiOptions
+                    {
+                        BaseUrl = _appConfiguration["AI:Groq:BaseUrl"] ?? "https://api.groq.com/openai/v1/responses",
+                        ApiKey = _appConfiguration["AI:Groq:ApiKey"],
+                        Model = _appConfiguration["AI:Groq:Model"],
+                        TimeoutSeconds = ReadIntegerSetting("AI:Groq:TimeoutSeconds", 60),
+                        MaxOutputTokens = ReadIntegerSetting("AI:Groq:MaxOutputTokens", 800),
+                        ReasoningEffort = _appConfiguration["AI:Groq:ReasoningEffort"]
+                    })
+                    .LifestyleSingleton());
         }
 
         private bool ReadBooleanSetting(string key, bool defaultValue)

--- a/aspnet-core/src/AstraLab.Web.Host/appsettings.json
+++ b/aspnet-core/src/AstraLab.Web.Host/appsettings.json
@@ -38,6 +38,16 @@
     "DefaultArtifactStorageProvider": "local-filesystem",
     "ArtifactRootPath": "App_Data/MLArtifacts"
   },
+  "AI": {
+    "Groq": {
+      "BaseUrl": "https://api.groq.com/openai/v1/responses",
+      "ApiKey": "",
+      "Model": "",
+      "TimeoutSeconds": 60,
+      "MaxOutputTokens": 800,
+      "ReasoningEffort": ""
+    }
+  },
   "Swagger": {
     "ShowSummaries": false
   }

--- a/aspnet-core/test/AstraLab.Tests/Domains/AI/AIResponseEntity_Tests.cs
+++ b/aspnet-core/test/AstraLab.Tests/Domains/AI/AIResponseEntity_Tests.cs
@@ -1,0 +1,359 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Abp.Runtime.Session;
+using AstraLab.Core.Domains.AI;
+using AstraLab.Core.Domains.Datasets;
+using Microsoft.EntityFrameworkCore;
+using Shouldly;
+using Xunit;
+
+namespace AstraLab.Tests.Domains.AI
+{
+    public class AIResponseEntity_Tests : AstraLabTestBase
+    {
+        [Fact]
+        public async Task Should_Persist_A_One_Off_AI_Response_As_A_Single_Response_Conversation_And_Load_The_Full_Relationship_Graph()
+        {
+            long conversationId = 0;
+            long responseId = 0;
+            long datasetId = 0;
+            long datasetVersionId = 0;
+            DateTime lastInteractionTime = new DateTime(2026, 4, 2, 8, 30, 0, DateTimeKind.Utc);
+
+            await UsingDbContextAsync(async context =>
+            {
+                var dataset = await CreateDatasetAsync(context, "ai-one-off-dataset");
+                var datasetVersion = await CreateDatasetVersionAsync(context, dataset.Id, 1, DatasetVersionType.Raw);
+
+                var conversation = context.AIConversations.Add(new AIConversation
+                {
+                    TenantId = dataset.TenantId,
+                    DatasetId = dataset.Id,
+                    OwnerUserId = dataset.OwnerUserId,
+                    LastInteractionTime = lastInteractionTime
+                }).Entity;
+
+                await context.SaveChangesAsync();
+
+                var response = context.AIResponses.Add(new AIResponse
+                {
+                    TenantId = dataset.TenantId,
+                    AIConversationId = conversation.Id,
+                    DatasetVersionId = datasetVersion.Id,
+                    UserQuery = "Summarize this dataset.",
+                    ResponseContent = "This dataset contains one raw version with clean structural metadata.",
+                    ResponseType = AIResponseType.Summary,
+                    MetadataJson = "{\"source\":\"dataset-profile\"}"
+                }).Entity;
+
+                await context.SaveChangesAsync();
+
+                datasetId = dataset.Id;
+                datasetVersionId = datasetVersion.Id;
+                conversationId = conversation.Id;
+                responseId = response.Id;
+            });
+
+            await UsingDbContextAsync(async context =>
+            {
+                var conversation = await context.AIConversations
+                    .Include(item => item.Dataset)
+                    .Include(item => item.Responses)
+                    .SingleAsync(item => item.Id == conversationId);
+
+                conversation.DatasetId.ShouldBe(datasetId);
+                conversation.Dataset.Id.ShouldBe(datasetId);
+                conversation.OwnerUserId.ShouldBe(AbpSession.GetUserId());
+                conversation.LastInteractionTime.ShouldBe(lastInteractionTime);
+                conversation.Responses.Count.ShouldBe(1);
+                conversation.Responses.Single().Id.ShouldBe(responseId);
+
+                var response = await context.AIResponses
+                    .Include(item => item.AIConversation)
+                    .Include(item => item.DatasetVersion)
+                    .SingleAsync(item => item.Id == responseId);
+
+                response.AIConversation.Id.ShouldBe(conversationId);
+                response.DatasetVersion.Id.ShouldBe(datasetVersionId);
+                response.UserQuery.ShouldBe("Summarize this dataset.");
+                response.ResponseContent.ShouldBe("This dataset contains one raw version with clean structural metadata.");
+                response.ResponseType.ShouldBe(AIResponseType.Summary);
+                response.MetadataJson.ShouldBe("{\"source\":\"dataset-profile\"}");
+            });
+        }
+
+        [Fact]
+        public async Task Should_Persist_Multiple_AI_Responses_In_A_Single_Conversation_In_Chronological_Order()
+        {
+            long conversationId = 0;
+
+            await UsingDbContextAsync(async context =>
+            {
+                var dataset = await CreateDatasetAsync(context, "ai-multi-turn-dataset");
+                var rawVersion = await CreateDatasetVersionAsync(context, dataset.Id, 1, DatasetVersionType.Raw);
+                var processedVersion = await CreateDatasetVersionAsync(context, dataset.Id, 2, DatasetVersionType.Processed, rawVersion.Id);
+
+                var conversation = context.AIConversations.Add(new AIConversation
+                {
+                    TenantId = dataset.TenantId,
+                    DatasetId = dataset.Id,
+                    OwnerUserId = dataset.OwnerUserId,
+                    LastInteractionTime = new DateTime(2026, 4, 2, 9, 5, 0, DateTimeKind.Utc)
+                }).Entity;
+
+                await context.SaveChangesAsync();
+
+                context.AIResponses.Add(new AIResponse
+                {
+                    TenantId = dataset.TenantId,
+                    AIConversationId = conversation.Id,
+                    DatasetVersionId = rawVersion.Id,
+                    UserQuery = "What quality issues should I fix first?",
+                    ResponseContent = "Start with missing-value handling on the raw version.",
+                    ResponseType = AIResponseType.Recommendation,
+                    CreationTime = new DateTime(2026, 4, 2, 9, 0, 0, DateTimeKind.Utc)
+                });
+
+                context.AIResponses.Add(new AIResponse
+                {
+                    TenantId = dataset.TenantId,
+                    AIConversationId = conversation.Id,
+                    DatasetVersionId = processedVersion.Id,
+                    UserQuery = "Explain why this processed version looks better.",
+                    ResponseContent = "The processed version reduces null-heavy rows and keeps the dominant schema intact.",
+                    ResponseType = AIResponseType.Explanation,
+                    CreationTime = new DateTime(2026, 4, 2, 9, 1, 0, DateTimeKind.Utc)
+                });
+
+                await context.SaveChangesAsync();
+                conversationId = conversation.Id;
+            });
+
+            await UsingDbContextAsync(async context =>
+            {
+                var orderedResponses = await context.AIResponses
+                    .Where(item => item.AIConversationId == conversationId)
+                    .OrderBy(item => item.CreationTime)
+                    .Select(item => item.ResponseContent)
+                    .ToListAsync();
+
+                orderedResponses.Count.ShouldBe(2);
+                orderedResponses[0].ShouldBe("Start with missing-value handling on the raw version.");
+                orderedResponses[1].ShouldBe("The processed version reduces null-heavy rows and keeps the dominant schema intact.");
+            });
+        }
+
+        [Fact]
+        public async Task Should_Persist_An_AI_Response_With_An_Optional_Dataset_Transformation_Link()
+        {
+            long responseId = 0;
+            long transformationId = 0;
+
+            await UsingDbContextAsync(async context =>
+            {
+                var dataset = await CreateDatasetAsync(context, "ai-transformation-link-dataset");
+                var sourceVersion = await CreateDatasetVersionAsync(context, dataset.Id, 1, DatasetVersionType.Raw);
+                var resultVersion = await CreateDatasetVersionAsync(context, dataset.Id, 2, DatasetVersionType.Processed, sourceVersion.Id);
+
+                var transformation = context.DatasetTransformations.Add(new DatasetTransformation
+                {
+                    TenantId = dataset.TenantId,
+                    SourceDatasetVersionId = sourceVersion.Id,
+                    ResultDatasetVersionId = resultVersion.Id,
+                    TransformationType = DatasetTransformationType.RemoveDuplicates,
+                    ConfigurationJson = "{\"columns\":[\"customerId\"]}",
+                    ExecutionOrder = 1,
+                    ExecutedAt = new DateTime(2026, 4, 2, 9, 45, 0, DateTimeKind.Utc),
+                    SummaryJson = "{\"removedRows\":14}"
+                }).Entity;
+
+                await context.SaveChangesAsync();
+
+                var conversation = context.AIConversations.Add(new AIConversation
+                {
+                    TenantId = dataset.TenantId,
+                    DatasetId = dataset.Id,
+                    OwnerUserId = dataset.OwnerUserId,
+                    LastInteractionTime = new DateTime(2026, 4, 2, 9, 46, 0, DateTimeKind.Utc)
+                }).Entity;
+
+                await context.SaveChangesAsync();
+
+                var response = context.AIResponses.Add(new AIResponse
+                {
+                    TenantId = dataset.TenantId,
+                    AIConversationId = conversation.Id,
+                    DatasetVersionId = resultVersion.Id,
+                    ResponseContent = "Removing duplicate customer rows improved the data health score.",
+                    ResponseType = AIResponseType.Insight,
+                    DatasetTransformationId = transformation.Id
+                }).Entity;
+
+                await context.SaveChangesAsync();
+
+                transformationId = transformation.Id;
+                responseId = response.Id;
+            });
+
+            await UsingDbContextAsync(async context =>
+            {
+                var response = await context.AIResponses
+                    .Include(item => item.DatasetTransformation)
+                    .SingleAsync(item => item.Id == responseId);
+
+                response.DatasetTransformationId.ShouldBe(transformationId);
+                response.DatasetTransformation.ShouldNotBeNull();
+                response.DatasetTransformation.Id.ShouldBe(transformationId);
+            });
+        }
+
+        [Fact]
+        public void Should_Define_The_Expected_AI_Conversation_Index_In_Model()
+        {
+            UsingDbContext(context =>
+            {
+                var entityType = context.Model.FindEntityType(typeof(AIConversation));
+                var index = entityType.GetIndexes()
+                    .Single(item => item.Properties.Select(property => property.Name)
+                        .SequenceEqual(new[]
+                        {
+                            nameof(AIConversation.TenantId),
+                            nameof(AIConversation.DatasetId),
+                            nameof(AIConversation.OwnerUserId),
+                            nameof(AIConversation.LastInteractionTime)
+                        }));
+
+                index.IsUnique.ShouldBeFalse();
+            });
+        }
+
+        [Fact]
+        public void Should_Define_The_Expected_AI_Response_Indexes_In_Model()
+        {
+            UsingDbContext(context =>
+            {
+                var entityType = context.Model.FindEntityType(typeof(AIResponse));
+
+                var conversationIndex = entityType.GetIndexes()
+                    .Single(item => item.Properties.Select(property => property.Name)
+                        .SequenceEqual(new[] { nameof(AIResponse.AIConversationId), nameof(AIResponse.CreationTime) }));
+
+                var datasetVersionIndex = entityType.GetIndexes()
+                    .Single(item => item.Properties.Select(property => property.Name)
+                        .SequenceEqual(new[]
+                        {
+                            nameof(AIResponse.TenantId),
+                            nameof(AIResponse.DatasetVersionId),
+                            nameof(AIResponse.ResponseType),
+                            nameof(AIResponse.CreationTime)
+                        }));
+
+                var transformationIndex = entityType.GetIndexes()
+                    .Single(item => item.Properties.Select(property => property.Name)
+                        .SequenceEqual(new[] { nameof(AIResponse.DatasetTransformationId) }));
+
+                conversationIndex.IsUnique.ShouldBeFalse();
+                datasetVersionIndex.IsUnique.ShouldBeFalse();
+                transformationIndex.IsUnique.ShouldBeFalse();
+            });
+        }
+
+        [Fact]
+        public void Should_Define_Cascade_Delete_From_Dataset_To_AI_Conversation_In_Model()
+        {
+            UsingDbContext(context =>
+            {
+                var entityType = context.Model.FindEntityType(typeof(AIConversation));
+                var foreignKey = entityType.GetForeignKeys()
+                    .Single(item =>
+                        item.Properties.Single().Name == nameof(AIConversation.DatasetId) &&
+                        item.PrincipalEntityType.ClrType == typeof(Dataset));
+
+                foreignKey.DeleteBehavior.ShouldBe(DeleteBehavior.Cascade);
+            });
+        }
+
+        [Fact]
+        public void Should_Define_Cascade_Delete_From_AI_Conversation_To_AI_Response_In_Model()
+        {
+            UsingDbContext(context =>
+            {
+                var entityType = context.Model.FindEntityType(typeof(AIResponse));
+                var foreignKey = entityType.GetForeignKeys()
+                    .Single(item =>
+                        item.Properties.Single().Name == nameof(AIResponse.AIConversationId) &&
+                        item.PrincipalEntityType.ClrType == typeof(AIConversation));
+
+                foreignKey.DeleteBehavior.ShouldBe(DeleteBehavior.Cascade);
+            });
+        }
+
+        [Fact]
+        public void Should_Define_Cascade_Delete_From_Dataset_Version_To_AI_Response_In_Model()
+        {
+            UsingDbContext(context =>
+            {
+                var entityType = context.Model.FindEntityType(typeof(AIResponse));
+                var foreignKey = entityType.GetForeignKeys()
+                    .Single(item =>
+                        item.Properties.Single().Name == nameof(AIResponse.DatasetVersionId) &&
+                        item.PrincipalEntityType.ClrType == typeof(DatasetVersion));
+
+                foreignKey.DeleteBehavior.ShouldBe(DeleteBehavior.Cascade);
+            });
+        }
+
+        [Fact]
+        public void Should_Define_Restrict_Delete_From_Dataset_Transformation_To_AI_Response_In_Model()
+        {
+            UsingDbContext(context =>
+            {
+                var entityType = context.Model.FindEntityType(typeof(AIResponse));
+                var foreignKey = entityType.GetForeignKeys()
+                    .Single(item =>
+                        item.Properties.Single().Name == nameof(AIResponse.DatasetTransformationId) &&
+                        item.PrincipalEntityType.ClrType == typeof(DatasetTransformation));
+
+                foreignKey.DeleteBehavior.ShouldBe(DeleteBehavior.Restrict);
+            });
+        }
+
+        private async Task<Dataset> CreateDatasetAsync(AstraLab.EntityFrameworkCore.AstraLabDbContext context, string name)
+        {
+            var dataset = context.Datasets.Add(new Dataset
+            {
+                TenantId = AbpSession.GetTenantId(),
+                Name = name,
+                SourceFormat = DatasetFormat.Csv,
+                OwnerUserId = AbpSession.GetUserId(),
+                OriginalFileName = name + ".csv"
+            }).Entity;
+
+            await context.SaveChangesAsync();
+            return dataset;
+        }
+
+        private async Task<DatasetVersion> CreateDatasetVersionAsync(
+            AstraLab.EntityFrameworkCore.AstraLabDbContext context,
+            long datasetId,
+            int versionNumber,
+            DatasetVersionType versionType,
+            long? parentVersionId = null)
+        {
+            var datasetVersion = context.DatasetVersions.Add(new DatasetVersion
+            {
+                TenantId = AbpSession.GetTenantId(),
+                DatasetId = datasetId,
+                VersionNumber = versionNumber,
+                VersionType = versionType,
+                Status = DatasetVersionStatus.Active,
+                ParentVersionId = parentVersionId,
+                SizeBytes = 256
+            }).Entity;
+
+            await context.SaveChangesAsync();
+            return datasetVersion;
+        }
+    }
+}

--- a/aspnet-core/test/AstraLab.Tests/Services/AI/AiDatasetContextBuilder_Tests.cs
+++ b/aspnet-core/test/AstraLab.Tests/Services/AI/AiDatasetContextBuilder_Tests.cs
@@ -1,0 +1,315 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Abp.Domain.Entities;
+using Abp.Runtime.Session;
+using AstraLab.Core.Domains.Datasets;
+using AstraLab.MultiTenancy;
+using AstraLab.Services.AI;
+using Shouldly;
+using Xunit;
+
+namespace AstraLab.Tests.Services.AI
+{
+    public class AiDatasetContextBuilder_Tests : AstraLabTestBase
+    {
+        private readonly IAiDatasetContextBuilder _aiDatasetContextBuilder;
+
+        public AiDatasetContextBuilder_Tests()
+        {
+            _aiDatasetContextBuilder = Resolve<IAiDatasetContextBuilder>();
+        }
+
+        [Fact]
+        public async Task BuildAsync_Should_Return_Structured_Context_For_A_Profiled_Dataset_Version()
+        {
+            var currentUserId = AbpSession.GetUserId();
+            var datasetVersionId = UsingDbContext(context =>
+            {
+                var dataset = CreateDataset(context, "ai-context-profiled", "Context description", currentUserId);
+                var datasetVersion = CreateDatasetVersion(context, dataset.Id, 1, DatasetVersionType.Raw);
+
+                datasetVersion.SchemaJson = "{\"columns\":[{\"name\":\"amount\"}]}";
+                datasetVersion.RowCount = 3;
+                datasetVersion.ColumnCount = 2;
+
+                var amountColumn = context.DatasetColumns.Add(new DatasetColumn
+                {
+                    TenantId = 1,
+                    DatasetVersionId = datasetVersion.Id,
+                    Name = "amount",
+                    DataType = "decimal",
+                    IsDataTypeInferred = true,
+                    Ordinal = 1,
+                    NullCount = 1,
+                    DistinctCount = 2
+                }).Entity;
+
+                context.DatasetColumns.Add(new DatasetColumn
+                {
+                    TenantId = 1,
+                    DatasetVersionId = datasetVersion.Id,
+                    Name = "customer_id",
+                    DataType = "integer",
+                    IsDataTypeInferred = true,
+                    Ordinal = 2,
+                    NullCount = 0,
+                    DistinctCount = 3
+                });
+
+                var datasetProfile = context.DatasetProfiles.Add(new DatasetProfile
+                {
+                    TenantId = 1,
+                    DatasetVersionId = datasetVersion.Id,
+                    RowCount = 3,
+                    DuplicateRowCount = 1,
+                    DataHealthScore = 88.50m,
+                    SummaryJson = "{\"totalNullCount\":1,\"overallNullPercentage\":16.67,\"totalAnomalyCount\":1,\"overallAnomalyPercentage\":33.33}",
+                    CreationTime = new DateTime(2026, 4, 2, 10, 15, 0, DateTimeKind.Utc)
+                }).Entity;
+
+                context.SaveChanges();
+
+                context.DatasetColumnProfiles.Add(new DatasetColumnProfile
+                {
+                    TenantId = 1,
+                    DatasetProfileId = datasetProfile.Id,
+                    DatasetColumnId = amountColumn.Id,
+                    InferredDataType = "decimal",
+                    NullCount = 1,
+                    DistinctCount = 2,
+                    StatisticsJson = "{\"nullPercentage\":33.33,\"mean\":10.5,\"min\":1.0,\"max\":20.0,\"anomalyCount\":1,\"anomalyPercentage\":33.33,\"hasAnomalies\":true}"
+                });
+
+                context.SaveChanges();
+                return datasetVersion.Id;
+            });
+
+            var output = await _aiDatasetContextBuilder.BuildAsync(datasetVersionId, AbpSession.GetTenantId(), currentUserId);
+
+            output.Dataset.DatasetId.ShouldBeGreaterThan(0L);
+            output.Dataset.Name.ShouldBe("ai-context-profiled");
+            output.Version.DatasetVersionId.ShouldBe(datasetVersionId);
+            output.Schema.HasSchemaJson.ShouldBeTrue();
+            output.Schema.TotalColumnCount.ShouldBe(2);
+            output.Profiling.ShouldNotBeNull();
+            output.Profiling.DataHealthScore.ShouldBe(88.50m);
+            output.Columns.Count.ShouldBe(2);
+
+            var amountColumn = output.Columns.Single(item => item.Name == "amount");
+            amountColumn.HasDetailedProfile.ShouldBeTrue();
+            amountColumn.ProfiledInferredDataType.ShouldBe("decimal");
+            amountColumn.NullPercentage.ShouldBe(33.33m);
+            amountColumn.HasAnomalies.ShouldBe(true);
+
+            var customerIdColumn = output.Columns.Single(item => item.Name == "customer_id");
+            customerIdColumn.HasDetailedProfile.ShouldBeFalse();
+            customerIdColumn.NullCount.ShouldBe(0);
+            customerIdColumn.DistinctCount.ShouldBe(3);
+        }
+
+        [Fact]
+        public async Task BuildAsync_Should_Return_Valid_Context_When_Profile_Is_Missing()
+        {
+            var currentUserId = AbpSession.GetUserId();
+            var datasetVersionId = UsingDbContext(context =>
+            {
+                var dataset = CreateDataset(context, "ai-context-unprofiled", null, currentUserId);
+                var datasetVersion = CreateDatasetVersion(context, dataset.Id, 1, DatasetVersionType.Raw);
+
+                context.DatasetColumns.Add(new DatasetColumn
+                {
+                    TenantId = 1,
+                    DatasetVersionId = datasetVersion.Id,
+                    Name = "name",
+                    DataType = "string",
+                    IsDataTypeInferred = true,
+                    Ordinal = 1
+                });
+
+                context.SaveChanges();
+                return datasetVersion.Id;
+            });
+
+            var output = await _aiDatasetContextBuilder.BuildAsync(datasetVersionId, AbpSession.GetTenantId(), currentUserId);
+
+            output.Dataset.Name.ShouldBe("ai-context-unprofiled");
+            output.Profiling.ShouldBeNull();
+            output.Columns.Count.ShouldBe(1);
+            output.Columns.Single().HasDetailedProfile.ShouldBeFalse();
+        }
+
+        [Fact]
+        public async Task BuildAsync_Should_Prune_Detailed_Column_Context_For_Wide_Datasets_And_Keep_High_Risk_Columns()
+        {
+            var currentUserId = AbpSession.GetUserId();
+            var datasetVersionId = UsingDbContext(context =>
+            {
+                var dataset = CreateDataset(context, "ai-context-wide", "wide dataset", currentUserId);
+                var datasetVersion = CreateDatasetVersion(context, dataset.Id, 1, DatasetVersionType.Raw);
+
+                var datasetProfile = context.DatasetProfiles.Add(new DatasetProfile
+                {
+                    TenantId = 1,
+                    DatasetVersionId = datasetVersion.Id,
+                    RowCount = 100,
+                    DuplicateRowCount = 0,
+                    DataHealthScore = 70m,
+                    SummaryJson = "{\"totalNullCount\":100,\"overallNullPercentage\":10.0,\"totalAnomalyCount\":10,\"overallAnomalyPercentage\":5.0}"
+                }).Entity;
+
+                context.SaveChanges();
+
+                for (var ordinal = 1; ordinal <= 25; ordinal++)
+                {
+                    var column = context.DatasetColumns.Add(new DatasetColumn
+                    {
+                        TenantId = 1,
+                        DatasetVersionId = datasetVersion.Id,
+                        Name = ordinal == 1 ? "high_nulls" : ordinal == 2 ? "anomaly_amount" : "column_" + ordinal,
+                        DataType = ordinal % 2 == 0 ? "decimal" : "string",
+                        IsDataTypeInferred = true,
+                        Ordinal = ordinal,
+                        NullCount = ordinal == 1 ? 60 : 0,
+                        DistinctCount = ordinal == 2 ? 90 : ordinal
+                    }).Entity;
+
+                    context.SaveChanges();
+
+                    var statisticsJson = ordinal == 1
+                        ? "{\"nullPercentage\":60.0,\"mean\":null,\"min\":null,\"max\":null,\"anomalyCount\":0,\"anomalyPercentage\":0.0,\"hasAnomalies\":false}"
+                        : ordinal == 2
+                            ? "{\"nullPercentage\":0.0,\"mean\":25.0,\"min\":1.0,\"max\":999.0,\"anomalyCount\":5,\"anomalyPercentage\":25.0,\"hasAnomalies\":true}"
+                            : "{\"nullPercentage\":0.0,\"mean\":1.0,\"min\":1.0,\"max\":1.0,\"anomalyCount\":0,\"anomalyPercentage\":0.0,\"hasAnomalies\":false}";
+
+                    context.DatasetColumnProfiles.Add(new DatasetColumnProfile
+                    {
+                        TenantId = 1,
+                        DatasetProfileId = datasetProfile.Id,
+                        DatasetColumnId = column.Id,
+                        InferredDataType = column.DataType,
+                        NullCount = column.NullCount ?? 0,
+                        DistinctCount = column.DistinctCount,
+                        StatisticsJson = statisticsJson
+                    });
+                }
+
+                context.SaveChanges();
+                return datasetVersion.Id;
+            });
+
+            var output = await _aiDatasetContextBuilder.BuildAsync(datasetVersionId, AbpSession.GetTenantId(), currentUserId);
+
+            output.Columns.Count.ShouldBe(25);
+            output.IsColumnContextPruned.ShouldBeTrue();
+            output.DetailedColumnCount.ShouldBe(AiDatasetContextDefaults.MaxProfiledColumnsInCompactSummary);
+
+            var highNullColumn = output.Columns.Single(item => item.Name == "high_nulls");
+            var anomalyColumn = output.Columns.Single(item => item.Name == "anomaly_amount");
+
+            highNullColumn.HasDetailedProfile.ShouldBeTrue();
+            anomalyColumn.HasDetailedProfile.ShouldBeTrue();
+            anomalyColumn.HasAnomalies.ShouldBe(true);
+        }
+
+        [Fact]
+        public async Task BuildAsync_Should_Throw_When_Dataset_Version_Belongs_To_A_Different_Owner()
+        {
+            var currentUserId = AbpSession.GetUserId();
+            var datasetVersionId = UsingDbContext(context =>
+            {
+                var dataset = CreateDataset(context, "ai-context-hidden", null, currentUserId + 10);
+                var datasetVersion = CreateDatasetVersion(context, dataset.Id, 1, DatasetVersionType.Raw);
+                return datasetVersion.Id;
+            });
+
+            await Should.ThrowAsync<EntityNotFoundException>(() =>
+                _aiDatasetContextBuilder.BuildAsync(datasetVersionId, AbpSession.GetTenantId(), currentUserId));
+        }
+
+        [Fact]
+        public async Task BuildAsync_Should_Throw_When_Dataset_Version_Belongs_To_A_Different_Tenant()
+        {
+            var currentUserId = AbpSession.GetUserId();
+            var otherTenantId = UsingDbContext((int?)null, context =>
+            {
+                var tenant = context.Tenants.Add(new Tenant("ai-context-other-tenant", "AI Context Other Tenant")).Entity;
+                context.SaveChanges();
+                return tenant.Id;
+            });
+
+            var datasetVersionId = UsingDbContext(otherTenantId, context =>
+            {
+                var dataset = context.Datasets.Add(new Dataset
+                {
+                    TenantId = otherTenantId,
+                    Name = "ai-context-other-tenant-dataset",
+                    SourceFormat = DatasetFormat.Csv,
+                    Status = DatasetStatus.Ready,
+                    OwnerUserId = 999,
+                    OriginalFileName = "other-tenant.csv"
+                }).Entity;
+
+                context.SaveChanges();
+
+                var datasetVersion = context.DatasetVersions.Add(new DatasetVersion
+                {
+                    TenantId = otherTenantId,
+                    DatasetId = dataset.Id,
+                    VersionNumber = 1,
+                    VersionType = DatasetVersionType.Raw,
+                    Status = DatasetVersionStatus.Active,
+                    SizeBytes = 15
+                }).Entity;
+
+                context.SaveChanges();
+                return datasetVersion.Id;
+            });
+
+            await Should.ThrowAsync<EntityNotFoundException>(() =>
+                _aiDatasetContextBuilder.BuildAsync(datasetVersionId, AbpSession.GetTenantId(), currentUserId));
+        }
+
+        private static Dataset CreateDataset(
+            AstraLab.EntityFrameworkCore.AstraLabDbContext context,
+            string name,
+            string description,
+            long ownerUserId)
+        {
+            var dataset = context.Datasets.Add(new Dataset
+            {
+                TenantId = 1,
+                Name = name,
+                Description = description,
+                SourceFormat = DatasetFormat.Csv,
+                Status = DatasetStatus.Ready,
+                OwnerUserId = ownerUserId,
+                OriginalFileName = name + ".csv"
+            }).Entity;
+
+            context.SaveChanges();
+            return dataset;
+        }
+
+        private static DatasetVersion CreateDatasetVersion(
+            AstraLab.EntityFrameworkCore.AstraLabDbContext context,
+            long datasetId,
+            int versionNumber,
+            DatasetVersionType versionType)
+        {
+            var datasetVersion = context.DatasetVersions.Add(new DatasetVersion
+            {
+                TenantId = 1,
+                DatasetId = datasetId,
+                VersionNumber = versionNumber,
+                VersionType = versionType,
+                Status = DatasetVersionStatus.Active,
+                SizeBytes = 128,
+                CreationTime = new DateTime(2026, 4, 2, 10, 0, 0, DateTimeKind.Utc)
+            }).Entity;
+
+            context.SaveChanges();
+            return datasetVersion;
+        }
+    }
+}

--- a/aspnet-core/test/AstraLab.Tests/Services/AI/AiPromptBuilder_Tests.cs
+++ b/aspnet-core/test/AstraLab.Tests/Services/AI/AiPromptBuilder_Tests.cs
@@ -70,6 +70,25 @@ namespace AstraLab.Tests.Services.AI
             questionAnswerResult.UserMessage.ShouldContain("Answer first in one short paragraph");
         }
 
+        [Fact]
+        public void Build_Should_Use_Four_Section_Automatic_Insight_Prompt_Rules()
+        {
+            var result = _aiPromptBuilder.Build(new AiPromptBuildRequest
+            {
+                ResponseType = AIResponseType.Insight,
+                DatasetContext = BuildDatasetContext(),
+                EnrichmentContext = new AiDatasetInsightContext
+                {
+                    DatasetVersionId = 100
+                },
+                IsAutomaticProfilingInsight = true
+            });
+
+            result.SystemInstructions.ShouldContain("Return exactly four short sections titled Summary");
+            result.UserMessage.ShouldContain("Generate an automatic dataset insight after profiling completed.");
+            result.UserMessage.ShouldContain("Use exactly these headings in order: Summary, Key data quality issues, Notable patterns or anomalies, Suggested next steps.");
+        }
+
         private static AiDatasetContext BuildDatasetContext()
         {
             return new AiDatasetContext

--- a/aspnet-core/test/AstraLab.Tests/Services/AI/AiPromptBuilder_Tests.cs
+++ b/aspnet-core/test/AstraLab.Tests/Services/AI/AiPromptBuilder_Tests.cs
@@ -1,0 +1,123 @@
+using AstraLab.Core.Domains.AI;
+using AstraLab.Core.Domains.Datasets;
+using AstraLab.Services.AI;
+using Shouldly;
+using Xunit;
+
+namespace AstraLab.Tests.Services.AI
+{
+    public class AiPromptBuilder_Tests
+    {
+        private readonly IAiPromptBuilder _aiPromptBuilder;
+
+        public AiPromptBuilder_Tests()
+        {
+            _aiPromptBuilder = new AiPromptBuilder();
+        }
+
+        [Fact]
+        public void Build_Should_Inject_Base_Dataset_Context_For_Summaries()
+        {
+            var result = _aiPromptBuilder.Build(new AiPromptBuildRequest
+            {
+                ResponseType = AIResponseType.Summary,
+                DatasetContext = BuildDatasetContext(),
+                EnrichmentContext = null
+            });
+
+            result.SystemInstructions.ShouldContain("dataset assistant");
+            result.UserMessage.ShouldContain("Dataset context JSON:");
+            result.UserMessage.ShouldContain("sales-dataset");
+            result.UserMessage.ShouldContain("Generate a dataset summary.");
+            result.UserMessage.ShouldNotContain("Additional enrichment JSON:");
+        }
+
+        [Fact]
+        public void Build_Should_Include_Enrichment_For_Recommendations_And_Question_Text_For_QA()
+        {
+            var recommendationResult = _aiPromptBuilder.Build(new AiPromptBuildRequest
+            {
+                ResponseType = AIResponseType.Recommendation,
+                DatasetContext = BuildDatasetContext(),
+                EnrichmentContext = new AiDatasetInsightContext
+                {
+                    DatasetVersionId = 100,
+                    HighSignalColumns = new[]
+                    {
+                        new AiInsightColumnContext
+                        {
+                            DatasetColumnId = 3,
+                            Name = "amount",
+                            DataType = "decimal",
+                            NullPercentage = 40m
+                        }
+                    }
+                }
+            });
+
+            recommendationResult.UserMessage.ShouldContain("Additional enrichment JSON:");
+            recommendationResult.UserMessage.ShouldContain("amount");
+
+            var questionAnswerResult = _aiPromptBuilder.Build(new AiPromptBuildRequest
+            {
+                ResponseType = AIResponseType.QuestionAnswer,
+                DatasetContext = BuildDatasetContext(),
+                UserQuestion = "What are the biggest risks?"
+            });
+
+            questionAnswerResult.UserMessage.ShouldContain("User question:");
+            questionAnswerResult.UserMessage.ShouldContain("What are the biggest risks?");
+            questionAnswerResult.UserMessage.ShouldContain("Answer first in one short paragraph");
+        }
+
+        private static AiDatasetContext BuildDatasetContext()
+        {
+            return new AiDatasetContext
+            {
+                Dataset = new AiDatasetSummaryContext
+                {
+                    DatasetId = 1,
+                    Name = "sales-dataset",
+                    Description = "Quarterly sales data",
+                    SourceFormat = DatasetFormat.Csv,
+                    Status = DatasetStatus.Ready,
+                    OwnerUserId = 42
+                },
+                Version = new AiDatasetVersionContext
+                {
+                    DatasetVersionId = 100,
+                    DatasetId = 1,
+                    VersionNumber = 1,
+                    VersionType = DatasetVersionType.Raw,
+                    Status = DatasetVersionStatus.Active
+                },
+                Schema = new AiSchemaContext
+                {
+                    TotalColumnCount = 2,
+                    HasSchemaJson = true,
+                    SchemaJsonPreview = "{\"columns\":[{\"name\":\"amount\"}]}"
+                },
+                Profiling = new AiProfilingContext
+                {
+                    ProfileId = 88,
+                    RowCount = 10,
+                    DuplicateRowCount = 1,
+                    DataHealthScore = 82.5m
+                },
+                Columns = new[]
+                {
+                    new AiColumnContext
+                    {
+                        DatasetColumnId = 3,
+                        Name = "amount",
+                        Ordinal = 1,
+                        DataType = "decimal",
+                        HasDetailedProfile = true,
+                        NullPercentage = 20m
+                    }
+                },
+                DetailedColumnCount = 1
+            };
+        }
+    }
+}

--- a/aspnet-core/test/AstraLab.Tests/Services/AI/AiPromptBuilder_Tests.cs
+++ b/aspnet-core/test/AstraLab.Tests/Services/AI/AiPromptBuilder_Tests.cs
@@ -89,6 +89,38 @@ namespace AstraLab.Tests.Services.AI
             result.UserMessage.ShouldContain("Use exactly these headings in order: Summary, Key data quality issues, Notable patterns or anomalies, Suggested next steps.");
         }
 
+        [Fact]
+        public void Build_Should_Inject_Ml_Experiment_Context_And_Use_Experiment_Specific_Rules()
+        {
+            var result = _aiPromptBuilder.Build(new AiPromptBuildRequest
+            {
+                ResponseType = AIResponseType.Summary,
+                DatasetContext = BuildDatasetContext(),
+                MlExperimentContext = new AiMlExperimentContext
+                {
+                    MLExperimentId = 55,
+                    DatasetVersionId = 100,
+                    AlgorithmKey = "random_forest_classifier",
+                    ModelType = "random_forest_classifier",
+                    HasModelOutput = true,
+                    FeatureNames = new[] { "amount", "region" },
+                    Metrics = new[]
+                    {
+                        new AiMlMetricContext
+                        {
+                            MetricName = "accuracy",
+                            MetricValue = 0.91m
+                        }
+                    }
+                }
+            });
+
+            result.SystemInstructions.ShouldContain("machine learning experiment context");
+            result.UserMessage.ShouldContain("Machine learning experiment context JSON:");
+            result.UserMessage.ShouldContain("random_forest_classifier");
+            result.UserMessage.ShouldContain("Generate a machine learning experiment summary.");
+        }
+
         private static AiDatasetContext BuildDatasetContext()
         {
             return new AiDatasetContext

--- a/aspnet-core/test/AstraLab.Tests/Services/AI/DatasetAiAppService_Tests.cs
+++ b/aspnet-core/test/AstraLab.Tests/Services/AI/DatasetAiAppService_Tests.cs
@@ -1,0 +1,373 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Abp.Application.Services.Dto;
+using Abp.Domain.Entities;
+using Abp.Runtime.Session;
+using Abp.UI;
+using AstraLab.Core.Domains.AI;
+using AstraLab.Core.Domains.Datasets;
+using AstraLab.Services.AI;
+using AstraLab.Services.AI.Dto;
+using Castle.MicroKernel.Registration;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace AstraLab.Tests.Services.AI
+{
+    public class DatasetAiAppService_Tests : AstraLabTestBase
+    {
+        private readonly IAiTextGenerationClient _aiTextGenerationClient;
+        private readonly IDatasetAiAppService _datasetAiAppService;
+
+        public DatasetAiAppService_Tests()
+        {
+            _aiTextGenerationClient = Substitute.For<IAiTextGenerationClient>();
+
+            LocalIocManager.IocContainer.Register(
+                Component.For<IAiTextGenerationClient>()
+                    .Instance(_aiTextGenerationClient)
+                    .IsDefault()
+                    .LifestyleSingleton());
+
+            _datasetAiAppService = Resolve<IDatasetAiAppService>();
+        }
+
+        [Fact]
+        public async Task GenerateSummaryAsync_Should_Create_A_Persisted_Summary_Response_And_Conversation()
+        {
+            var datasetVersionId = UsingDbContext(context =>
+            {
+                var dataset = CreateDataset(context, "ai-summary-dataset", AbpSession.GetUserId());
+                var datasetVersion = CreateDatasetVersion(context, dataset.Id, 1, DatasetVersionType.Raw);
+                AddProfileData(context, datasetVersion.Id, "amount");
+                return datasetVersion.Id;
+            });
+
+            _aiTextGenerationClient.GenerateTextAsync(Arg.Any<AiTextGenerationRequest>())
+                .Returns(Task.FromResult(new AiTextGenerationResult
+                {
+                    Text = "This dataset is small and mostly clean.",
+                    Provider = "groq",
+                    Model = "llama-test",
+                    ProviderResponseId = "resp_summary",
+                    UsageJson = "{\"output_tokens\":12}"
+                }));
+
+            var result = await _datasetAiAppService.GenerateSummaryAsync(new EntityDto<long>(datasetVersionId));
+
+            result.ConversationId.ShouldBeGreaterThan(0L);
+            result.Response.ResponseType.ShouldBe(AIResponseType.Summary);
+            result.Response.UserQuery.ShouldBeNull();
+            result.Response.ResponseContent.ShouldBe("This dataset is small and mostly clean.");
+            result.Response.MetadataJson.ShouldContain("\"provider\":\"groq\"");
+            result.Response.MetadataJson.ShouldContain("\"totalColumns\":1");
+
+            await UsingDbContextAsync(async context =>
+            {
+                context.AIConversations.Count().ShouldBe(1);
+                context.AIResponses.Count().ShouldBe(1);
+                context.AIResponses.Single().AIConversationId.ShouldBe(result.ConversationId);
+                await Task.CompletedTask;
+            });
+        }
+
+        [Fact]
+        public async Task GenerateCleaningRecommendationsAsync_Should_Include_Enrichment_And_Persist_A_Recommendation()
+        {
+            var datasetVersionId = UsingDbContext(context =>
+            {
+                var dataset = CreateDataset(context, "ai-recommendation-dataset", AbpSession.GetUserId());
+                var datasetVersion = CreateDatasetVersion(context, dataset.Id, 1, DatasetVersionType.Raw);
+                AddProfileData(context, datasetVersion.Id, "amount");
+                context.DatasetTransformations.Add(new DatasetTransformation
+                {
+                    TenantId = 1,
+                    SourceDatasetVersionId = datasetVersion.Id,
+                    ResultDatasetVersionId = null,
+                    TransformationType = DatasetTransformationType.RemoveDuplicates,
+                    ConfigurationJson = "{\"columns\":[]}",
+                    ExecutionOrder = 1,
+                    ExecutedAt = new DateTime(2026, 4, 2, 12, 0, 0, DateTimeKind.Utc),
+                    SummaryJson = "{\"removedRows\":4}"
+                });
+                context.SaveChanges();
+                return datasetVersion.Id;
+            });
+
+            AiTextGenerationRequest capturedRequest = null;
+            _aiTextGenerationClient.GenerateTextAsync(Arg.Do<AiTextGenerationRequest>(item => capturedRequest = item))
+                .Returns(Task.FromResult(new AiTextGenerationResult
+                {
+                    Text = "Prioritize missing-value cleanup on amount and then remove duplicates.",
+                    Provider = "groq",
+                    Model = "llama-test",
+                    ProviderResponseId = "resp_recommendation"
+                }));
+
+            var result = await _datasetAiAppService.GenerateCleaningRecommendationsAsync(new EntityDto<long>(datasetVersionId));
+
+            result.Response.ResponseType.ShouldBe(AIResponseType.Recommendation);
+            capturedRequest.ShouldNotBeNull();
+            capturedRequest.UserMessage.ShouldContain("Additional enrichment JSON:");
+            capturedRequest.UserMessage.ShouldContain("amount");
+            capturedRequest.UserMessage.ShouldContain("removeDuplicates");
+        }
+
+        [Fact]
+        public async Task AskAsync_Should_Replay_Prior_Turns_And_Persist_A_Question_Answer_Response()
+        {
+            var scenario = UsingDbContext(context =>
+            {
+                var dataset = CreateDataset(context, "ai-qa-dataset", AbpSession.GetUserId());
+                var datasetVersion = CreateDatasetVersion(context, dataset.Id, 1, DatasetVersionType.Raw);
+                AddProfileData(context, datasetVersion.Id, "sales");
+
+                var conversation = context.AIConversations.Add(new AIConversation
+                {
+                    TenantId = 1,
+                    DatasetId = dataset.Id,
+                    OwnerUserId = AbpSession.GetUserId(),
+                    LastInteractionTime = new DateTime(2026, 4, 2, 11, 0, 0, DateTimeKind.Utc)
+                }).Entity;
+
+                context.SaveChanges();
+
+                context.AIResponses.Add(new AIResponse
+                {
+                    TenantId = 1,
+                    AIConversationId = conversation.Id,
+                    DatasetVersionId = datasetVersion.Id,
+                    UserQuery = "What stands out first?",
+                    ResponseContent = "Nulls in sales are the biggest issue.",
+                    ResponseType = AIResponseType.QuestionAnswer
+                });
+                context.SaveChanges();
+
+                return new
+                {
+                    datasetVersion.Id,
+                    ConversationId = conversation.Id
+                };
+            });
+
+            AiTextGenerationRequest capturedRequest = null;
+            _aiTextGenerationClient.GenerateTextAsync(Arg.Do<AiTextGenerationRequest>(item => capturedRequest = item))
+                .Returns(Task.FromResult(new AiTextGenerationResult
+                {
+                    Text = "Sales has moderate null exposure but otherwise looks stable.",
+                    Provider = "groq",
+                    Model = "llama-test",
+                    ProviderResponseId = "resp_qa"
+                }));
+
+            var result = await _datasetAiAppService.AskAsync(new AskDatasetAiQuestionRequest
+            {
+                DatasetVersionId = scenario.Id,
+                ConversationId = scenario.ConversationId,
+                Question = "How healthy is this dataset?"
+            });
+
+            result.ConversationId.ShouldBe(scenario.ConversationId);
+            result.Response.ResponseType.ShouldBe(AIResponseType.QuestionAnswer);
+            result.Response.UserQuery.ShouldBe("How healthy is this dataset?");
+            capturedRequest.ConversationHistory.Count.ShouldBe(2);
+            capturedRequest.ConversationHistory[0].Role.ShouldBe("user");
+            capturedRequest.ConversationHistory[1].Role.ShouldBe("assistant");
+        }
+
+        [Fact]
+        public async Task AskAsync_Should_Reject_An_Empty_Question()
+        {
+            var datasetVersionId = UsingDbContext(context =>
+            {
+                var dataset = CreateDataset(context, "ai-empty-question-dataset", AbpSession.GetUserId());
+                return CreateDatasetVersion(context, dataset.Id, 1, DatasetVersionType.Raw).Id;
+            });
+
+            var exception = await Should.ThrowAsync<UserFriendlyException>(() =>
+                _datasetAiAppService.AskAsync(new AskDatasetAiQuestionRequest
+                {
+                    DatasetVersionId = datasetVersionId,
+                    Question = "   "
+                }));
+
+            exception.Message.ShouldBe("A question is required for dataset AI Q&A.");
+        }
+
+        [Fact]
+        public async Task AskAsync_Should_Reject_Conversation_Reuse_Across_Different_Dataset_Versions()
+        {
+            var scenario = UsingDbContext(context =>
+            {
+                var dataset = CreateDataset(context, "ai-version-mismatch-dataset", AbpSession.GetUserId());
+                var rawVersion = CreateDatasetVersion(context, dataset.Id, 1, DatasetVersionType.Raw);
+                var processedVersion = CreateDatasetVersion(context, dataset.Id, 2, DatasetVersionType.Processed, rawVersion.Id);
+                AddProfileData(context, rawVersion.Id, "amount");
+                AddProfileData(context, processedVersion.Id, "amount");
+
+                var conversation = context.AIConversations.Add(new AIConversation
+                {
+                    TenantId = 1,
+                    DatasetId = dataset.Id,
+                    OwnerUserId = AbpSession.GetUserId(),
+                    LastInteractionTime = new DateTime(2026, 4, 2, 11, 0, 0, DateTimeKind.Utc)
+                }).Entity;
+
+                context.SaveChanges();
+
+                context.AIResponses.Add(new AIResponse
+                {
+                    TenantId = 1,
+                    AIConversationId = conversation.Id,
+                    DatasetVersionId = rawVersion.Id,
+                    UserQuery = "Old question",
+                    ResponseContent = "Old answer",
+                    ResponseType = AIResponseType.QuestionAnswer
+                });
+                context.SaveChanges();
+
+                return new
+                {
+                    RawVersionId = rawVersion.Id,
+                    ProcessedVersionId = processedVersion.Id,
+                    ConversationId = conversation.Id
+                };
+            });
+
+            var exception = await Should.ThrowAsync<UserFriendlyException>(() =>
+                _datasetAiAppService.AskAsync(new AskDatasetAiQuestionRequest
+                {
+                    DatasetVersionId = scenario.ProcessedVersionId,
+                    ConversationId = scenario.ConversationId,
+                    Question = "Can I continue this thread?"
+                }));
+
+            exception.Message.ShouldBe("The selected AI conversation belongs to a different dataset version and cannot be reused for this Q&A request.");
+        }
+
+        [Fact]
+        public async Task GenerateSummaryAsync_Should_Reject_A_Dataset_Version_From_A_Different_Owner()
+        {
+            var datasetVersionId = UsingDbContext(context =>
+            {
+                var dataset = CreateDataset(context, "ai-owner-dataset", AbpSession.GetUserId() + 10);
+                return CreateDatasetVersion(context, dataset.Id, 1, DatasetVersionType.Raw).Id;
+            });
+
+            await Should.ThrowAsync<EntityNotFoundException>(() =>
+                _datasetAiAppService.GenerateSummaryAsync(new EntityDto<long>(datasetVersionId)));
+        }
+
+        [Fact]
+        public async Task GenerateInsightsAsync_Should_Not_Persist_Partial_Records_When_The_Provider_Fails()
+        {
+            var datasetVersionId = UsingDbContext(context =>
+            {
+                var dataset = CreateDataset(context, "ai-failing-provider-dataset", AbpSession.GetUserId());
+                var datasetVersion = CreateDatasetVersion(context, dataset.Id, 1, DatasetVersionType.Raw);
+                AddProfileData(context, datasetVersion.Id, "amount");
+                return datasetVersion.Id;
+            });
+
+            _aiTextGenerationClient.GenerateTextAsync(Arg.Any<AiTextGenerationRequest>())
+                .Returns<Task<AiTextGenerationResult>>(_ => throw new UserFriendlyException("Provider down."));
+
+            await Should.ThrowAsync<UserFriendlyException>(() =>
+                _datasetAiAppService.GenerateInsightsAsync(new EntityDto<long>(datasetVersionId)));
+
+            await UsingDbContextAsync(async context =>
+            {
+                context.AIConversations.Count().ShouldBe(0);
+                context.AIResponses.Count().ShouldBe(0);
+                await Task.CompletedTask;
+            });
+        }
+
+        private static Dataset CreateDataset(AstraLab.EntityFrameworkCore.AstraLabDbContext context, string name, long ownerUserId)
+        {
+            var dataset = context.Datasets.Add(new Dataset
+            {
+                TenantId = 1,
+                Name = name,
+                Description = name + " description",
+                SourceFormat = DatasetFormat.Csv,
+                Status = DatasetStatus.Ready,
+                OwnerUserId = ownerUserId,
+                OriginalFileName = name + ".csv"
+            }).Entity;
+
+            context.SaveChanges();
+            return dataset;
+        }
+
+        private static DatasetVersion CreateDatasetVersion(
+            AstraLab.EntityFrameworkCore.AstraLabDbContext context,
+            long datasetId,
+            int versionNumber,
+            DatasetVersionType versionType,
+            long? parentVersionId = null)
+        {
+            var datasetVersion = context.DatasetVersions.Add(new DatasetVersion
+            {
+                TenantId = 1,
+                DatasetId = datasetId,
+                VersionNumber = versionNumber,
+                VersionType = versionType,
+                Status = DatasetVersionStatus.Active,
+                ParentVersionId = parentVersionId,
+                RowCount = 10,
+                ColumnCount = 1,
+                SchemaJson = "{\"columns\":[{\"name\":\"amount\"}]}",
+                SizeBytes = 256,
+                CreationTime = new DateTime(2026, 4, 2, 10, 0, 0, DateTimeKind.Utc)
+            }).Entity;
+
+            context.SaveChanges();
+            return datasetVersion;
+        }
+
+        private static void AddProfileData(AstraLab.EntityFrameworkCore.AstraLabDbContext context, long datasetVersionId, string columnName)
+        {
+            var column = context.DatasetColumns.Add(new DatasetColumn
+            {
+                TenantId = 1,
+                DatasetVersionId = datasetVersionId,
+                Name = columnName,
+                DataType = "decimal",
+                IsDataTypeInferred = true,
+                Ordinal = 1,
+                NullCount = 2,
+                DistinctCount = 6
+            }).Entity;
+
+            context.SaveChanges();
+
+            var datasetProfile = context.DatasetProfiles.Add(new DatasetProfile
+            {
+                TenantId = 1,
+                DatasetVersionId = datasetVersionId,
+                RowCount = 10,
+                DuplicateRowCount = 1,
+                DataHealthScore = 82.5m,
+                SummaryJson = "{\"totalNullCount\":2,\"overallNullPercentage\":20.0,\"totalAnomalyCount\":1,\"overallAnomalyPercentage\":10.0}"
+            }).Entity;
+
+            context.SaveChanges();
+
+            context.DatasetColumnProfiles.Add(new DatasetColumnProfile
+            {
+                TenantId = 1,
+                DatasetProfileId = datasetProfile.Id,
+                DatasetColumnId = column.Id,
+                InferredDataType = "decimal",
+                NullCount = 2,
+                DistinctCount = 6,
+                StatisticsJson = "{\"nullPercentage\":20.0,\"mean\":10.5,\"min\":1.0,\"max\":22.0,\"anomalyCount\":1,\"anomalyPercentage\":10.0,\"hasAnomalies\":true}"
+            });
+
+            context.SaveChanges();
+        }
+    }
+}

--- a/aspnet-core/test/AstraLab.Tests/Services/AI/DatasetAiAppService_Tests.cs
+++ b/aspnet-core/test/AstraLab.Tests/Services/AI/DatasetAiAppService_Tests.cs
@@ -285,6 +285,289 @@ namespace AstraLab.Tests.Services.AI
             });
         }
 
+        [Fact]
+        public async Task GetLatestAutomaticInsightAsync_Should_Return_The_Newest_Profiling_Triggered_Insight_Only()
+        {
+            var datasetVersionId = UsingDbContext(context =>
+            {
+                var dataset = CreateDataset(context, "ai-auto-insight-dataset", AbpSession.GetUserId());
+                var datasetVersion = CreateDatasetVersion(context, dataset.Id, 1, DatasetVersionType.Raw);
+                AddProfileData(context, datasetVersion.Id, "amount");
+
+                var conversation = context.AIConversations.Add(new AIConversation
+                {
+                    TenantId = 1,
+                    DatasetId = dataset.Id,
+                    OwnerUserId = AbpSession.GetUserId(),
+                    LastInteractionTime = new DateTime(2026, 4, 2, 11, 0, 0, DateTimeKind.Utc)
+                }).Entity;
+
+                context.SaveChanges();
+
+                context.AIResponses.Add(new AIResponse
+                {
+                    TenantId = 1,
+                    AIConversationId = conversation.Id,
+                    DatasetVersionId = datasetVersion.Id,
+                    ResponseContent = "Manual insight.",
+                    ResponseType = AIResponseType.Insight,
+                    MetadataJson = "{\"provider\":\"groq\"}",
+                    CreationTime = new DateTime(2026, 4, 2, 11, 5, 0, DateTimeKind.Utc)
+                });
+
+                context.AIResponses.Add(new AIResponse
+                {
+                    TenantId = 1,
+                    AIConversationId = conversation.Id,
+                    DatasetVersionId = datasetVersion.Id,
+                    ResponseContent = "Older automatic insight.",
+                    ResponseType = AIResponseType.Insight,
+                    MetadataJson = "{\"generationTrigger\":\"profilingCompleted\",\"datasetProfileId\":1,\"provider\":\"groq\"}",
+                    CreationTime = new DateTime(2026, 4, 2, 11, 10, 0, DateTimeKind.Utc)
+                });
+
+                context.AIResponses.Add(new AIResponse
+                {
+                    TenantId = 1,
+                    AIConversationId = conversation.Id,
+                    DatasetVersionId = datasetVersion.Id,
+                    ResponseContent = "Latest automatic insight.",
+                    ResponseType = AIResponseType.Insight,
+                    MetadataJson = "{\"generationTrigger\":\"profilingCompleted\",\"datasetProfileId\":2,\"provider\":\"groq\"}",
+                    CreationTime = new DateTime(2026, 4, 2, 11, 20, 0, DateTimeKind.Utc)
+                });
+
+                context.SaveChanges();
+                return datasetVersion.Id;
+            });
+
+            var result = await _datasetAiAppService.GetLatestAutomaticInsightAsync(new EntityDto<long>(datasetVersionId));
+
+            result.ShouldNotBeNull();
+            result.ResponseContent.ShouldBe("Latest automatic insight.");
+        }
+
+        [Fact]
+        public async Task GetConversationAsync_Should_Return_The_Persisted_Conversation_Summary()
+        {
+            var scenario = UsingDbContext(context =>
+            {
+                var dataset = CreateDataset(context, "ai-get-conversation-dataset", AbpSession.GetUserId());
+                var datasetVersion = CreateDatasetVersion(context, dataset.Id, 1, DatasetVersionType.Raw);
+
+                var conversation = context.AIConversations.Add(new AIConversation
+                {
+                    TenantId = 1,
+                    DatasetId = dataset.Id,
+                    OwnerUserId = AbpSession.GetUserId(),
+                    LastInteractionTime = new DateTime(2026, 4, 2, 11, 30, 0, DateTimeKind.Utc)
+                }).Entity;
+
+                context.SaveChanges();
+
+                context.AIResponses.Add(new AIResponse
+                {
+                    TenantId = 1,
+                    AIConversationId = conversation.Id,
+                    DatasetVersionId = datasetVersion.Id,
+                    UserQuery = "Summarize this data",
+                    ResponseContent = "A concise summary for the assistant route.",
+                    ResponseType = AIResponseType.Summary,
+                    CreationTime = new DateTime(2026, 4, 2, 11, 31, 0, DateTimeKind.Utc)
+                });
+                context.SaveChanges();
+
+                return conversation.Id;
+            });
+
+            var result = await _datasetAiAppService.GetConversationAsync(new EntityDto<long>(scenario));
+
+            result.ShouldNotBeNull();
+            result.Id.ShouldBe(scenario);
+            result.ResponseCount.ShouldBe(1);
+            result.LatestResponseType.ShouldBe(AIResponseType.Summary);
+            result.LatestUserQuery.ShouldBe("Summarize this data");
+            result.LatestResponsePreview.ShouldContain("assistant route");
+        }
+
+        [Fact]
+        public async Task GetConversationsAsync_Should_Filter_By_Dataset_Version_And_Sort_By_Latest_Interaction()
+        {
+            var scenario = UsingDbContext(context =>
+            {
+                var dataset = CreateDataset(context, "ai-conversation-list-dataset", AbpSession.GetUserId());
+                var rawVersion = CreateDatasetVersion(context, dataset.Id, 1, DatasetVersionType.Raw);
+                var processedVersion = CreateDatasetVersion(context, dataset.Id, 2, DatasetVersionType.Processed, rawVersion.Id);
+
+                var olderConversation = context.AIConversations.Add(new AIConversation
+                {
+                    TenantId = 1,
+                    DatasetId = dataset.Id,
+                    OwnerUserId = AbpSession.GetUserId(),
+                    LastInteractionTime = new DateTime(2026, 4, 2, 10, 0, 0, DateTimeKind.Utc)
+                }).Entity;
+                var newerConversation = context.AIConversations.Add(new AIConversation
+                {
+                    TenantId = 1,
+                    DatasetId = dataset.Id,
+                    OwnerUserId = AbpSession.GetUserId(),
+                    LastInteractionTime = new DateTime(2026, 4, 2, 12, 0, 0, DateTimeKind.Utc)
+                }).Entity;
+
+                context.SaveChanges();
+
+                context.AIResponses.Add(new AIResponse
+                {
+                    TenantId = 1,
+                    AIConversationId = olderConversation.Id,
+                    DatasetVersionId = rawVersion.Id,
+                    ResponseContent = "Older raw-version conversation.",
+                    ResponseType = AIResponseType.Summary,
+                    CreationTime = new DateTime(2026, 4, 2, 10, 5, 0, DateTimeKind.Utc)
+                });
+                context.AIResponses.Add(new AIResponse
+                {
+                    TenantId = 1,
+                    AIConversationId = newerConversation.Id,
+                    DatasetVersionId = processedVersion.Id,
+                    ResponseContent = "Newer processed-version conversation.",
+                    ResponseType = AIResponseType.QuestionAnswer,
+                    CreationTime = new DateTime(2026, 4, 2, 12, 5, 0, DateTimeKind.Utc)
+                });
+
+                context.SaveChanges();
+
+                return new
+                {
+                    DatasetId = dataset.Id,
+                    RawVersionId = rawVersion.Id,
+                    ProcessedVersionId = processedVersion.Id,
+                    OlderConversationId = olderConversation.Id,
+                    NewerConversationId = newerConversation.Id
+                };
+            });
+
+            var allResults = await _datasetAiAppService.GetConversationsAsync(new GetDatasetAiConversationsRequest
+            {
+                DatasetId = scenario.DatasetId,
+                SkipCount = 0,
+                MaxResultCount = 10
+            });
+
+            allResults.TotalCount.ShouldBe(2);
+            allResults.Items.First().Id.ShouldBe(scenario.NewerConversationId);
+            allResults.Items.Last().Id.ShouldBe(scenario.OlderConversationId);
+
+            var filteredResults = await _datasetAiAppService.GetConversationsAsync(new GetDatasetAiConversationsRequest
+            {
+                DatasetId = scenario.DatasetId,
+                DatasetVersionId = scenario.RawVersionId,
+                SkipCount = 0,
+                MaxResultCount = 10
+            });
+
+            filteredResults.TotalCount.ShouldBe(1);
+            filteredResults.Items.Single().Id.ShouldBe(scenario.OlderConversationId);
+        }
+
+        [Fact]
+        public async Task GetResponsesAsync_Should_Return_Chronological_Conversation_Turns()
+        {
+            var scenario = UsingDbContext(context =>
+            {
+                var dataset = CreateDataset(context, "ai-response-thread-dataset", AbpSession.GetUserId());
+                var datasetVersion = CreateDatasetVersion(context, dataset.Id, 1, DatasetVersionType.Raw);
+
+                var conversation = context.AIConversations.Add(new AIConversation
+                {
+                    TenantId = 1,
+                    DatasetId = dataset.Id,
+                    OwnerUserId = AbpSession.GetUserId(),
+                    LastInteractionTime = new DateTime(2026, 4, 2, 12, 0, 0, DateTimeKind.Utc)
+                }).Entity;
+
+                context.SaveChanges();
+
+                context.AIResponses.Add(new AIResponse
+                {
+                    TenantId = 1,
+                    AIConversationId = conversation.Id,
+                    DatasetVersionId = datasetVersion.Id,
+                    UserQuery = "First question",
+                    ResponseContent = "First answer",
+                    ResponseType = AIResponseType.QuestionAnswer,
+                    CreationTime = new DateTime(2026, 4, 2, 10, 0, 0, DateTimeKind.Utc)
+                });
+                context.AIResponses.Add(new AIResponse
+                {
+                    TenantId = 1,
+                    AIConversationId = conversation.Id,
+                    DatasetVersionId = datasetVersion.Id,
+                    UserQuery = "Second question",
+                    ResponseContent = "Second answer",
+                    ResponseType = AIResponseType.QuestionAnswer,
+                    CreationTime = new DateTime(2026, 4, 2, 11, 0, 0, DateTimeKind.Utc)
+                });
+
+                context.SaveChanges();
+                return conversation.Id;
+            });
+
+            var result = await _datasetAiAppService.GetResponsesAsync(new GetDatasetAiResponsesRequest
+            {
+                ConversationId = scenario,
+                SkipCount = 0,
+                MaxResultCount = 10,
+                IsChronological = true
+            });
+
+            result.TotalCount.ShouldBe(2);
+            result.Items.First().UserQuery.ShouldBe("First question");
+            result.Items.Last().UserQuery.ShouldBe("Second question");
+        }
+
+        [Fact]
+        public async Task GetResponsesAsync_Should_Reject_A_Conversation_From_A_Different_Owner()
+        {
+            var conversationId = UsingDbContext(context =>
+            {
+                var dataset = CreateDataset(context, "ai-foreign-conversation-dataset", AbpSession.GetUserId() + 20);
+                var datasetVersion = CreateDatasetVersion(context, dataset.Id, 1, DatasetVersionType.Raw);
+
+                var conversation = context.AIConversations.Add(new AIConversation
+                {
+                    TenantId = 1,
+                    DatasetId = dataset.Id,
+                    OwnerUserId = dataset.OwnerUserId,
+                    LastInteractionTime = new DateTime(2026, 4, 2, 12, 0, 0, DateTimeKind.Utc)
+                }).Entity;
+
+                context.SaveChanges();
+
+                context.AIResponses.Add(new AIResponse
+                {
+                    TenantId = 1,
+                    AIConversationId = conversation.Id,
+                    DatasetVersionId = datasetVersion.Id,
+                    ResponseContent = "Foreign response",
+                    ResponseType = AIResponseType.Summary
+                });
+                context.SaveChanges();
+
+                return conversation.Id;
+            });
+
+            var exception = await Should.ThrowAsync<UserFriendlyException>(() =>
+                _datasetAiAppService.GetResponsesAsync(new GetDatasetAiResponsesRequest
+                {
+                    ConversationId = conversationId,
+                    SkipCount = 0,
+                    MaxResultCount = 10
+                }));
+
+            exception.Message.ShouldBe("The requested AI conversation could not be found.");
+        }
+
         private static Dataset CreateDataset(AstraLab.EntityFrameworkCore.AstraLabDbContext context, string name, long ownerUserId)
         {
             var dataset = context.Datasets.Add(new Dataset

--- a/aspnet-core/test/AstraLab.Tests/Services/AI/DatasetAiAppService_Tests.cs
+++ b/aspnet-core/test/AstraLab.Tests/Services/AI/DatasetAiAppService_Tests.cs
@@ -7,6 +7,7 @@ using Abp.Runtime.Session;
 using Abp.UI;
 using AstraLab.Core.Domains.AI;
 using AstraLab.Core.Domains.Datasets;
+using AstraLab.Core.Domains.ML;
 using AstraLab.Services.AI;
 using AstraLab.Services.AI.Dto;
 using Castle.MicroKernel.Registration;
@@ -248,6 +249,84 @@ namespace AstraLab.Tests.Services.AI
         }
 
         [Fact]
+        public async Task GenerateExperimentSummaryAsync_Should_Create_A_Persisted_Experiment_Linked_Response()
+        {
+            var experimentId = UsingDbContext(context =>
+            {
+                var dataset = CreateDataset(context, "ai-experiment-summary-dataset", AbpSession.GetUserId());
+                var datasetVersion = CreateDatasetVersion(context, dataset.Id, 1, DatasetVersionType.Raw);
+                var seeded = AddProfileData(context, datasetVersion.Id, "amount");
+                return CreateCompletedMlExperiment(context, datasetVersion.Id, seeded.ColumnId).Id;
+            });
+
+            _aiTextGenerationClient.GenerateTextAsync(Arg.Any<AiTextGenerationRequest>())
+                .Returns(Task.FromResult(new AiTextGenerationResult
+                {
+                    Text = "This experiment looks promising but needs stronger validation.",
+                    Provider = "groq",
+                    Model = "llama-test",
+                    ProviderResponseId = "resp_ml_summary"
+                }));
+
+            var result = await _datasetAiAppService.GenerateExperimentSummaryAsync(new EntityDto<long>(experimentId));
+
+            result.Response.ResponseType.ShouldBe(AIResponseType.Summary);
+            result.Response.MLExperimentId.ShouldBe(experimentId);
+            result.Response.MetadataJson.ShouldContain("\"mlExperimentId\":" + experimentId);
+        }
+
+        [Fact]
+        public async Task AskExperimentAsync_Should_Reject_Conversation_Reuse_Across_Different_Experiments()
+        {
+            var scenario = UsingDbContext(context =>
+            {
+                var dataset = CreateDataset(context, "ai-experiment-mismatch-dataset", AbpSession.GetUserId());
+                var datasetVersion = CreateDatasetVersion(context, dataset.Id, 1, DatasetVersionType.Raw);
+                var seeded = AddProfileData(context, datasetVersion.Id, "amount");
+                var firstExperiment = CreateCompletedMlExperiment(context, datasetVersion.Id, seeded.ColumnId);
+                var secondExperiment = CreateCompletedMlExperiment(context, datasetVersion.Id, seeded.ColumnId, "linear_regression");
+
+                var conversation = context.AIConversations.Add(new AIConversation
+                {
+                    TenantId = 1,
+                    DatasetId = dataset.Id,
+                    OwnerUserId = AbpSession.GetUserId(),
+                    LastInteractionTime = new DateTime(2026, 4, 2, 13, 0, 0, DateTimeKind.Utc)
+                }).Entity;
+
+                context.SaveChanges();
+
+                context.AIResponses.Add(new AIResponse
+                {
+                    TenantId = 1,
+                    AIConversationId = conversation.Id,
+                    DatasetVersionId = datasetVersion.Id,
+                    MLExperimentId = firstExperiment.Id,
+                    UserQuery = "How does the first run look?",
+                    ResponseContent = "It looks stable.",
+                    ResponseType = AIResponseType.QuestionAnswer
+                });
+                context.SaveChanges();
+
+                return new
+                {
+                    secondExperiment.Id,
+                    ConversationId = conversation.Id
+                };
+            });
+
+            var exception = await Should.ThrowAsync<UserFriendlyException>(() =>
+                _datasetAiAppService.AskExperimentAsync(new AskExperimentAiQuestionRequest
+                {
+                    MLExperimentId = scenario.Id,
+                    ConversationId = scenario.ConversationId,
+                    Question = "Can I continue this thread on another run?"
+                }));
+
+            exception.Message.ShouldBe("The selected AI conversation belongs to a different machine learning experiment and cannot be reused for this request.");
+        }
+
+        [Fact]
         public async Task GenerateSummaryAsync_Should_Reject_A_Dataset_Version_From_A_Different_Owner()
         {
             var datasetVersionId = UsingDbContext(context =>
@@ -345,6 +424,72 @@ namespace AstraLab.Tests.Services.AI
 
             result.ShouldNotBeNull();
             result.ResponseContent.ShouldBe("Latest automatic insight.");
+        }
+
+        [Fact]
+        public async Task GetLatestAutomaticExperimentInsightAsync_Should_Return_The_Newest_Experiment_Triggered_Insight_Only()
+        {
+            var experimentId = UsingDbContext(context =>
+            {
+                var dataset = CreateDataset(context, "ai-auto-experiment-insight-dataset", AbpSession.GetUserId());
+                var datasetVersion = CreateDatasetVersion(context, dataset.Id, 1, DatasetVersionType.Raw);
+                var seeded = AddProfileData(context, datasetVersion.Id, "amount");
+                var experiment = CreateCompletedMlExperiment(context, datasetVersion.Id, seeded.ColumnId);
+
+                var conversation = context.AIConversations.Add(new AIConversation
+                {
+                    TenantId = 1,
+                    DatasetId = dataset.Id,
+                    OwnerUserId = AbpSession.GetUserId(),
+                    LastInteractionTime = new DateTime(2026, 4, 2, 12, 30, 0, DateTimeKind.Utc)
+                }).Entity;
+
+                context.SaveChanges();
+
+                context.AIResponses.Add(new AIResponse
+                {
+                    TenantId = 1,
+                    AIConversationId = conversation.Id,
+                    DatasetVersionId = datasetVersion.Id,
+                    MLExperimentId = experiment.Id,
+                    ResponseContent = "Manual experiment insight.",
+                    ResponseType = AIResponseType.Insight,
+                    MetadataJson = "{\"provider\":\"groq\"}",
+                    CreationTime = new DateTime(2026, 4, 2, 12, 31, 0, DateTimeKind.Utc)
+                });
+
+                context.AIResponses.Add(new AIResponse
+                {
+                    TenantId = 1,
+                    AIConversationId = conversation.Id,
+                    DatasetVersionId = datasetVersion.Id,
+                    MLExperimentId = experiment.Id,
+                    ResponseContent = "Older automatic experiment insight.",
+                    ResponseType = AIResponseType.Insight,
+                    MetadataJson = "{\"generationTrigger\":\"experimentCompleted\",\"mlExperimentId\":" + experiment.Id + "}",
+                    CreationTime = new DateTime(2026, 4, 2, 12, 32, 0, DateTimeKind.Utc)
+                });
+
+                context.AIResponses.Add(new AIResponse
+                {
+                    TenantId = 1,
+                    AIConversationId = conversation.Id,
+                    DatasetVersionId = datasetVersion.Id,
+                    MLExperimentId = experiment.Id,
+                    ResponseContent = "Latest automatic experiment insight.",
+                    ResponseType = AIResponseType.Insight,
+                    MetadataJson = "{\"generationTrigger\":\"experimentCompleted\",\"mlExperimentId\":" + experiment.Id + "}",
+                    CreationTime = new DateTime(2026, 4, 2, 12, 33, 0, DateTimeKind.Utc)
+                });
+
+                context.SaveChanges();
+                return experiment.Id;
+            });
+
+            var result = await _datasetAiAppService.GetLatestAutomaticExperimentInsightAsync(new EntityDto<long>(experimentId));
+
+            result.ShouldNotBeNull();
+            result.ResponseContent.ShouldBe("Latest automatic experiment insight.");
         }
 
         [Fact]
@@ -468,6 +613,78 @@ namespace AstraLab.Tests.Services.AI
 
             filteredResults.TotalCount.ShouldBe(1);
             filteredResults.Items.Single().Id.ShouldBe(scenario.OlderConversationId);
+        }
+
+        [Fact]
+        public async Task GetConversationsAsync_Should_Filter_By_MLExperimentId()
+        {
+            var scenario = UsingDbContext(context =>
+            {
+                var dataset = CreateDataset(context, "ai-experiment-conversation-list-dataset", AbpSession.GetUserId());
+                var datasetVersion = CreateDatasetVersion(context, dataset.Id, 1, DatasetVersionType.Raw);
+                var seeded = AddProfileData(context, datasetVersion.Id, "amount");
+                var firstExperiment = CreateCompletedMlExperiment(context, datasetVersion.Id, seeded.ColumnId);
+                var secondExperiment = CreateCompletedMlExperiment(context, datasetVersion.Id, seeded.ColumnId, "linear_regression");
+
+                var firstConversation = context.AIConversations.Add(new AIConversation
+                {
+                    TenantId = 1,
+                    DatasetId = dataset.Id,
+                    OwnerUserId = AbpSession.GetUserId(),
+                    LastInteractionTime = new DateTime(2026, 4, 2, 12, 10, 0, DateTimeKind.Utc)
+                }).Entity;
+
+                var secondConversation = context.AIConversations.Add(new AIConversation
+                {
+                    TenantId = 1,
+                    DatasetId = dataset.Id,
+                    OwnerUserId = AbpSession.GetUserId(),
+                    LastInteractionTime = new DateTime(2026, 4, 2, 12, 20, 0, DateTimeKind.Utc)
+                }).Entity;
+
+                context.SaveChanges();
+
+                context.AIResponses.Add(new AIResponse
+                {
+                    TenantId = 1,
+                    AIConversationId = firstConversation.Id,
+                    DatasetVersionId = datasetVersion.Id,
+                    MLExperimentId = firstExperiment.Id,
+                    ResponseContent = "First experiment response.",
+                    ResponseType = AIResponseType.Summary
+                });
+
+                context.AIResponses.Add(new AIResponse
+                {
+                    TenantId = 1,
+                    AIConversationId = secondConversation.Id,
+                    DatasetVersionId = datasetVersion.Id,
+                    MLExperimentId = secondExperiment.Id,
+                    ResponseContent = "Second experiment response.",
+                    ResponseType = AIResponseType.Summary
+                });
+
+                context.SaveChanges();
+
+                return new
+                {
+                    DatasetId = dataset.Id,
+                    FirstExperimentId = firstExperiment.Id,
+                    SecondConversationId = secondConversation.Id
+                };
+            });
+
+            var result = await _datasetAiAppService.GetConversationsAsync(new GetDatasetAiConversationsRequest
+            {
+                DatasetId = scenario.DatasetId,
+                MLExperimentId = scenario.FirstExperimentId,
+                SkipCount = 0,
+                MaxResultCount = 10
+            });
+
+            result.TotalCount.ShouldBe(1);
+            result.Items.Single().LatestMLExperimentId.ShouldBe(scenario.FirstExperimentId);
+            result.Items.Single().Id.ShouldNotBe(scenario.SecondConversationId);
         }
 
         [Fact]
@@ -611,7 +828,7 @@ namespace AstraLab.Tests.Services.AI
             return datasetVersion;
         }
 
-        private static void AddProfileData(AstraLab.EntityFrameworkCore.AstraLabDbContext context, long datasetVersionId, string columnName)
+        private static ProfileSeedResult AddProfileData(AstraLab.EntityFrameworkCore.AstraLabDbContext context, long datasetVersionId, string columnName)
         {
             var column = context.DatasetColumns.Add(new DatasetColumn
             {
@@ -651,6 +868,68 @@ namespace AstraLab.Tests.Services.AI
             });
 
             context.SaveChanges();
+            return new ProfileSeedResult(column.Id, datasetProfile.Id);
+        }
+
+        private static MLExperiment CreateCompletedMlExperiment(
+            AstraLab.EntityFrameworkCore.AstraLabDbContext context,
+            long datasetVersionId,
+            long targetDatasetColumnId,
+            string algorithmKey = "random_forest_classifier")
+        {
+            var experiment = context.MLExperiments.Add(new MLExperiment
+            {
+                TenantId = 1,
+                DatasetVersionId = datasetVersionId,
+                TargetDatasetColumnId = targetDatasetColumnId,
+                Status = MLExperimentStatus.Completed,
+                TaskType = MLTaskType.Classification,
+                AlgorithmKey = algorithmKey,
+                TrainingConfigurationJson = "{\"testSize\":0.2}",
+                ExecutedAt = new DateTime(2026, 4, 2, 12, 0, 0, DateTimeKind.Utc),
+                StartedAtUtc = new DateTime(2026, 4, 2, 12, 1, 0, DateTimeKind.Utc),
+                CompletedAtUtc = new DateTime(2026, 4, 2, 12, 2, 0, DateTimeKind.Utc),
+                WarningsJson = "[\"class_imbalance\"]"
+            }).Entity;
+
+            context.SaveChanges();
+
+            var model = context.MLModels.Add(new MLModel
+            {
+                TenantId = 1,
+                MLExperimentId = experiment.Id,
+                ModelType = algorithmKey,
+                ArtifactStorageProvider = "local-filesystem",
+                ArtifactStorageKey = "ml-artifacts/test/model.joblib",
+                PerformanceSummaryJson = "{\"primaryMetric\":\"accuracy\"}",
+                WarningsJson = "[\"small_validation_split\"]"
+            }).Entity;
+
+            context.SaveChanges();
+
+            context.MLModelMetrics.Add(new MLModelMetric
+            {
+                TenantId = 1,
+                MLModelId = model.Id,
+                MetricName = "accuracy",
+                MetricValue = 0.91m
+            });
+
+            context.SaveChanges();
+            return experiment;
+        }
+
+        private class ProfileSeedResult
+        {
+            public ProfileSeedResult(long columnId, long datasetProfileId)
+            {
+                ColumnId = columnId;
+                DatasetProfileId = datasetProfileId;
+            }
+
+            public long ColumnId { get; }
+
+            public long DatasetProfileId { get; }
         }
     }
 }

--- a/aspnet-core/test/AstraLab.Tests/Services/AI/GenerateAutomaticDatasetInsightJob_Tests.cs
+++ b/aspnet-core/test/AstraLab.Tests/Services/AI/GenerateAutomaticDatasetInsightJob_Tests.cs
@@ -1,0 +1,202 @@
+using System;
+using System.Threading.Tasks;
+using Abp.Domain.Uow;
+using AstraLab.Core.Domains.AI;
+using AstraLab.Core.Domains.Datasets;
+using AstraLab.Services.AI;
+using Castle.MicroKernel.Registration;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace AstraLab.Tests.Services.AI
+{
+    public class GenerateAutomaticDatasetInsightJob_Tests : AstraLabTestBase
+    {
+        private readonly IAiDatasetResponseGenerator _aiDatasetResponseGenerator;
+
+        public GenerateAutomaticDatasetInsightJob_Tests()
+        {
+            _aiDatasetResponseGenerator = Substitute.For<IAiDatasetResponseGenerator>();
+
+            LocalIocManager.IocContainer.Register(
+                Component.For<IAiDatasetResponseGenerator>()
+                    .Instance(_aiDatasetResponseGenerator)
+                    .IsDefault()
+                    .LifestyleSingleton());
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_Should_Generate_When_Profile_Is_Current_And_No_Duplicate_Exists()
+        {
+            var args = UsingDbContext(context =>
+            {
+                var dataset = CreateDataset(context, "job-current-profile-dataset");
+                var datasetVersion = CreateDatasetVersion(context, dataset.Id);
+                var datasetProfile = CreateDatasetProfile(context, datasetVersion.Id);
+
+                return new GenerateAutomaticDatasetInsightJobArgs
+                {
+                    DatasetVersionId = datasetVersion.Id,
+                    DatasetProfileId = datasetProfile.Id,
+                    TenantId = 1,
+                    OwnerUserId = AbpSession.UserId.Value
+                };
+            });
+
+            _aiDatasetResponseGenerator.GenerateAutomaticInsightAsync(
+                    Arg.Any<long>(),
+                    Arg.Any<long>(),
+                    Arg.Any<int>(),
+                    Arg.Any<long>())
+                .Returns(Task.FromResult(new AstraLab.Services.AI.Dto.GenerateDatasetAiResponseResult()));
+
+            await ExecuteJobAsync(args);
+
+            await _aiDatasetResponseGenerator.Received(1).GenerateAutomaticInsightAsync(
+                args.DatasetVersionId,
+                args.DatasetProfileId,
+                args.TenantId,
+                args.OwnerUserId);
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_Should_Skip_When_Profile_Is_Stale()
+        {
+            var args = UsingDbContext(context =>
+            {
+                var dataset = CreateDataset(context, "job-stale-profile-dataset");
+                var datasetVersion = CreateDatasetVersion(context, dataset.Id);
+                CreateDatasetProfile(context, datasetVersion.Id);
+
+                return new GenerateAutomaticDatasetInsightJobArgs
+                {
+                    DatasetVersionId = datasetVersion.Id,
+                    DatasetProfileId = 999999,
+                    TenantId = 1,
+                    OwnerUserId = AbpSession.UserId.Value
+                };
+            });
+
+            await ExecuteJobAsync(args);
+
+            await _aiDatasetResponseGenerator.DidNotReceive().GenerateAutomaticInsightAsync(
+                Arg.Any<long>(),
+                Arg.Any<long>(),
+                Arg.Any<int>(),
+                Arg.Any<long>());
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_Should_Skip_When_Automatic_Insight_For_The_Same_Profile_Already_Exists()
+        {
+            var args = UsingDbContext(context =>
+            {
+                var dataset = CreateDataset(context, "job-duplicate-profile-dataset");
+                var datasetVersion = CreateDatasetVersion(context, dataset.Id);
+                var datasetProfile = CreateDatasetProfile(context, datasetVersion.Id);
+                var conversation = context.AIConversations.Add(new AIConversation
+                {
+                    TenantId = 1,
+                    DatasetId = dataset.Id,
+                    OwnerUserId = AbpSession.UserId.Value,
+                    LastInteractionTime = DateTime.UtcNow
+                }).Entity;
+
+                context.SaveChanges();
+
+                context.AIResponses.Add(new AIResponse
+                {
+                    TenantId = 1,
+                    AIConversationId = conversation.Id,
+                    DatasetVersionId = datasetVersion.Id,
+                    ResponseContent = "Already generated.",
+                    ResponseType = AIResponseType.Insight,
+                    MetadataJson = "{\"generationTrigger\":\"profilingCompleted\",\"datasetProfileId\":" + datasetProfile.Id + "}"
+                });
+                context.SaveChanges();
+
+                return new GenerateAutomaticDatasetInsightJobArgs
+                {
+                    DatasetVersionId = datasetVersion.Id,
+                    DatasetProfileId = datasetProfile.Id,
+                    TenantId = 1,
+                    OwnerUserId = AbpSession.UserId.Value
+                };
+            });
+
+            await ExecuteJobAsync(args);
+
+            await _aiDatasetResponseGenerator.DidNotReceive().GenerateAutomaticInsightAsync(
+                Arg.Any<long>(),
+                Arg.Any<long>(),
+                Arg.Any<int>(),
+                Arg.Any<long>());
+        }
+
+        private Dataset CreateDataset(AstraLab.EntityFrameworkCore.AstraLabDbContext context, string name)
+        {
+            var dataset = context.Datasets.Add(new Dataset
+            {
+                TenantId = 1,
+                Name = name,
+                Description = name + " description",
+                SourceFormat = DatasetFormat.Csv,
+                Status = DatasetStatus.Ready,
+                OwnerUserId = AbpSession.UserId.Value,
+                OriginalFileName = name + ".csv"
+            }).Entity;
+
+            context.SaveChanges();
+            return dataset;
+        }
+
+        private static DatasetVersion CreateDatasetVersion(
+            AstraLab.EntityFrameworkCore.AstraLabDbContext context,
+            long datasetId)
+        {
+            var datasetVersion = context.DatasetVersions.Add(new DatasetVersion
+            {
+                TenantId = 1,
+                DatasetId = datasetId,
+                VersionNumber = 1,
+                VersionType = DatasetVersionType.Raw,
+                Status = DatasetVersionStatus.Active,
+                RowCount = 12,
+                ColumnCount = 1,
+                SchemaJson = "{\"columns\":[{\"name\":\"amount\"}]}",
+                SizeBytes = 128
+            }).Entity;
+
+            context.SaveChanges();
+            return datasetVersion;
+        }
+
+        private static DatasetProfile CreateDatasetProfile(
+            AstraLab.EntityFrameworkCore.AstraLabDbContext context,
+            long datasetVersionId)
+        {
+            var profile = context.DatasetProfiles.Add(new DatasetProfile
+            {
+                TenantId = 1,
+                DatasetVersionId = datasetVersionId,
+                RowCount = 12,
+                DuplicateRowCount = 1,
+                DataHealthScore = 81.3m,
+                SummaryJson = "{\"totalNullCount\":2}"
+            }).Entity;
+
+            context.SaveChanges();
+            return profile;
+        }
+
+        private async Task ExecuteJobAsync(GenerateAutomaticDatasetInsightJobArgs args)
+        {
+            using (var unitOfWork = Resolve<IUnitOfWorkManager>().Begin())
+            {
+                await Resolve<GenerateAutomaticDatasetInsightJob>().ExecuteAsync(args);
+                await unitOfWork.CompleteAsync();
+            }
+        }
+    }
+}

--- a/aspnet-core/test/AstraLab.Tests/Services/AI/GenerateAutomaticExperimentInsightJob_Tests.cs
+++ b/aspnet-core/test/AstraLab.Tests/Services/AI/GenerateAutomaticExperimentInsightJob_Tests.cs
@@ -1,0 +1,220 @@
+using System;
+using System.Threading.Tasks;
+using Abp.Domain.Uow;
+using AstraLab.Core.Domains.AI;
+using AstraLab.Core.Domains.Datasets;
+using AstraLab.Core.Domains.ML;
+using AstraLab.Services.AI;
+using Castle.MicroKernel.Registration;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace AstraLab.Tests.Services.AI
+{
+    public class GenerateAutomaticExperimentInsightJob_Tests : AstraLabTestBase
+    {
+        private readonly IAiDatasetResponseGenerator _aiDatasetResponseGenerator;
+
+        public GenerateAutomaticExperimentInsightJob_Tests()
+        {
+            _aiDatasetResponseGenerator = Substitute.For<IAiDatasetResponseGenerator>();
+
+            LocalIocManager.IocContainer.Register(
+                Component.For<IAiDatasetResponseGenerator>()
+                    .Instance(_aiDatasetResponseGenerator)
+                    .IsDefault()
+                    .LifestyleSingleton());
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_Should_Generate_When_The_Experiment_Is_Completed_And_No_Duplicate_Exists()
+        {
+            var args = UsingDbContext(context =>
+            {
+                var dataset = CreateDataset(context, "job-current-experiment-dataset");
+                var datasetVersion = CreateDatasetVersion(context, dataset.Id);
+                var experiment = CreateCompletedExperiment(context, datasetVersion.Id);
+
+                return new GenerateAutomaticExperimentInsightJobArgs
+                {
+                    MLExperimentId = experiment.Id,
+                    DatasetVersionId = datasetVersion.Id,
+                    TenantId = 1,
+                    OwnerUserId = AbpSession.UserId.Value
+                };
+            });
+
+            _aiDatasetResponseGenerator.GenerateAutomaticExperimentInsightAsync(
+                    Arg.Any<long>(),
+                    Arg.Any<int>(),
+                    Arg.Any<long>())
+                .Returns(Task.FromResult(new AstraLab.Services.AI.Dto.GenerateDatasetAiResponseResult()));
+
+            await ExecuteJobAsync(args);
+
+            await _aiDatasetResponseGenerator.Received(1).GenerateAutomaticExperimentInsightAsync(
+                args.MLExperimentId,
+                args.TenantId,
+                args.OwnerUserId);
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_Should_Skip_When_The_Experiment_Is_Not_Completed()
+        {
+            var args = UsingDbContext(context =>
+            {
+                var dataset = CreateDataset(context, "job-pending-experiment-dataset");
+                var datasetVersion = CreateDatasetVersion(context, dataset.Id);
+                var experiment = CreateCompletedExperiment(context, datasetVersion.Id, MLExperimentStatus.Pending, includeModel: false);
+
+                return new GenerateAutomaticExperimentInsightJobArgs
+                {
+                    MLExperimentId = experiment.Id,
+                    DatasetVersionId = datasetVersion.Id,
+                    TenantId = 1,
+                    OwnerUserId = AbpSession.UserId.Value
+                };
+            });
+
+            await ExecuteJobAsync(args);
+
+            await _aiDatasetResponseGenerator.DidNotReceive().GenerateAutomaticExperimentInsightAsync(
+                Arg.Any<long>(),
+                Arg.Any<int>(),
+                Arg.Any<long>());
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_Should_Skip_When_Automatic_Insight_For_The_Experiment_Already_Exists()
+        {
+            var args = UsingDbContext(context =>
+            {
+                var dataset = CreateDataset(context, "job-duplicate-experiment-dataset");
+                var datasetVersion = CreateDatasetVersion(context, dataset.Id);
+                var experiment = CreateCompletedExperiment(context, datasetVersion.Id);
+                var conversation = context.AIConversations.Add(new AIConversation
+                {
+                    TenantId = 1,
+                    DatasetId = dataset.Id,
+                    OwnerUserId = AbpSession.UserId.Value,
+                    LastInteractionTime = DateTime.UtcNow
+                }).Entity;
+
+                context.SaveChanges();
+
+                context.AIResponses.Add(new AIResponse
+                {
+                    TenantId = 1,
+                    AIConversationId = conversation.Id,
+                    DatasetVersionId = datasetVersion.Id,
+                    MLExperimentId = experiment.Id,
+                    ResponseContent = "Already generated.",
+                    ResponseType = AIResponseType.Insight,
+                    MetadataJson = "{\"generationTrigger\":\"experimentCompleted\",\"mlExperimentId\":" + experiment.Id + "}"
+                });
+                context.SaveChanges();
+
+                return new GenerateAutomaticExperimentInsightJobArgs
+                {
+                    MLExperimentId = experiment.Id,
+                    DatasetVersionId = datasetVersion.Id,
+                    TenantId = 1,
+                    OwnerUserId = AbpSession.UserId.Value
+                };
+            });
+
+            await ExecuteJobAsync(args);
+
+            await _aiDatasetResponseGenerator.DidNotReceive().GenerateAutomaticExperimentInsightAsync(
+                Arg.Any<long>(),
+                Arg.Any<int>(),
+                Arg.Any<long>());
+        }
+
+        private Dataset CreateDataset(AstraLab.EntityFrameworkCore.AstraLabDbContext context, string name)
+        {
+            var dataset = context.Datasets.Add(new Dataset
+            {
+                TenantId = 1,
+                Name = name,
+                Description = name + " description",
+                SourceFormat = DatasetFormat.Csv,
+                Status = DatasetStatus.Ready,
+                OwnerUserId = AbpSession.UserId.Value,
+                OriginalFileName = name + ".csv"
+            }).Entity;
+
+            context.SaveChanges();
+            return dataset;
+        }
+
+        private static DatasetVersion CreateDatasetVersion(
+            AstraLab.EntityFrameworkCore.AstraLabDbContext context,
+            long datasetId)
+        {
+            var datasetVersion = context.DatasetVersions.Add(new DatasetVersion
+            {
+                TenantId = 1,
+                DatasetId = datasetId,
+                VersionNumber = 1,
+                VersionType = DatasetVersionType.Raw,
+                Status = DatasetVersionStatus.Active,
+                RowCount = 12,
+                ColumnCount = 1,
+                SchemaJson = "{\"columns\":[{\"name\":\"amount\"}]}",
+                SizeBytes = 128
+            }).Entity;
+
+            context.SaveChanges();
+            return datasetVersion;
+        }
+
+        private static MLExperiment CreateCompletedExperiment(
+            AstraLab.EntityFrameworkCore.AstraLabDbContext context,
+            long datasetVersionId,
+            MLExperimentStatus status = MLExperimentStatus.Completed,
+            bool includeModel = true)
+        {
+            var experiment = context.MLExperiments.Add(new MLExperiment
+            {
+                TenantId = 1,
+                DatasetVersionId = datasetVersionId,
+                Status = status,
+                TaskType = MLTaskType.Classification,
+                AlgorithmKey = "random_forest_classifier",
+                TrainingConfigurationJson = "{}",
+                ExecutedAt = DateTime.UtcNow,
+                StartedAtUtc = DateTime.UtcNow.AddMinutes(-3),
+                CompletedAtUtc = status == MLExperimentStatus.Completed
+                    ? DateTime.UtcNow.AddMinutes(-1)
+                    : (DateTime?)null
+            }).Entity;
+
+            context.SaveChanges();
+
+            if (includeModel)
+            {
+                context.MLModels.Add(new MLModel
+                {
+                    TenantId = 1,
+                    MLExperimentId = experiment.Id,
+                    ModelType = "random_forest_classifier",
+                    PerformanceSummaryJson = "{\"primaryMetric\":\"accuracy\"}"
+                });
+                context.SaveChanges();
+            }
+
+            return experiment;
+        }
+
+        private async Task ExecuteJobAsync(GenerateAutomaticExperimentInsightJobArgs args)
+        {
+            using (var unitOfWork = Resolve<IUnitOfWorkManager>().Begin())
+            {
+                await Resolve<GenerateAutomaticExperimentInsightJob>().ExecuteAsync(args);
+                await unitOfWork.CompleteAsync();
+            }
+        }
+    }
+}

--- a/aspnet-core/test/AstraLab.Tests/Services/AI/GroqAiTextGenerationClient_Tests.cs
+++ b/aspnet-core/test/AstraLab.Tests/Services/AI/GroqAiTextGenerationClient_Tests.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Abp.UI;
+using AstraLab.Services.AI;
+using Shouldly;
+using Xunit;
+
+namespace AstraLab.Tests.Services.AI
+{
+    public class GroqAiTextGenerationClient_Tests
+    {
+        [Fact]
+        public async Task GenerateTextAsync_Should_Send_A_Responses_Request_And_Map_The_Result()
+        {
+            var handler = new CapturingMessageHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    "{\"id\":\"resp_123\",\"model\":\"llama-test\",\"output\":[{\"content\":[{\"text\":\"Dataset looks healthy.\"}]}],\"usage\":{\"output_tokens\":12}}",
+                    Encoding.UTF8,
+                    "application/json")
+            });
+            var client = new GroqAiTextGenerationClient(
+                new FakeHttpClientFactory(new HttpClient(handler)),
+                new GroqAiOptions
+                {
+                    BaseUrl = "https://api.groq.com/openai/v1",
+                    ApiKey = "groq-key",
+                    Model = "llama-test",
+                    TimeoutSeconds = 30,
+                    MaxOutputTokens = 321,
+                    ReasoningEffort = "medium"
+                });
+
+            var result = await client.GenerateTextAsync(new AiTextGenerationRequest
+            {
+                SystemInstructions = "System prompt",
+                ConversationHistory = new[]
+                {
+                    new AiConversationHistoryMessage
+                    {
+                        Role = "assistant",
+                        Content = "Previous answer"
+                    }
+                },
+                UserMessage = "Current question"
+            });
+
+            handler.RequestUri.AbsoluteUri.ShouldBe("https://api.groq.com/openai/v1/responses");
+            handler.AuthorizationHeader.ShouldBe("Bearer groq-key");
+            handler.RequestBody.ShouldContain("\"model\":\"llama-test\"");
+            handler.RequestBody.ShouldContain("\"maxOutputTokens\":321");
+            handler.RequestBody.ShouldContain("\"effort\":\"medium\"");
+            handler.RequestBody.ShouldContain("System prompt");
+            handler.RequestBody.ShouldContain("Previous answer");
+            handler.RequestBody.ShouldContain("Current question");
+
+            result.Provider.ShouldBe("groq");
+            result.Model.ShouldBe("llama-test");
+            result.ProviderResponseId.ShouldBe("resp_123");
+            result.Text.ShouldBe("Dataset looks healthy.");
+            result.UsageJson.ShouldContain("output_tokens");
+        }
+
+        [Fact]
+        public async Task GenerateTextAsync_Should_Throw_A_Clear_Exception_When_The_Provider_Fails()
+        {
+            var handler = new CapturingMessageHandler(_ => new HttpResponseMessage(HttpStatusCode.BadRequest)
+            {
+                Content = new StringContent("{\"error\":\"bad request\"}", Encoding.UTF8, "application/json")
+            });
+            var client = new GroqAiTextGenerationClient(
+                new FakeHttpClientFactory(new HttpClient(handler)),
+                new GroqAiOptions
+                {
+                    BaseUrl = "https://api.groq.com/openai/v1/responses",
+                    ApiKey = "groq-key",
+                    Model = "llama-test",
+                    TimeoutSeconds = 30,
+                    MaxOutputTokens = 321
+                });
+
+            var exception = await Should.ThrowAsync<UserFriendlyException>(() =>
+                client.GenerateTextAsync(new AiTextGenerationRequest
+                {
+                    SystemInstructions = "System prompt",
+                    UserMessage = "Current question"
+                }));
+
+            exception.Message.ShouldContain("HTTP 400");
+        }
+
+        private class FakeHttpClientFactory : IHttpClientFactory
+        {
+            private readonly HttpClient _httpClient;
+
+            public FakeHttpClientFactory(HttpClient httpClient)
+            {
+                _httpClient = httpClient;
+            }
+
+            public HttpClient CreateClient(string name)
+            {
+                return _httpClient;
+            }
+        }
+
+        private class CapturingMessageHandler : HttpMessageHandler
+        {
+            private readonly Func<HttpRequestMessage, HttpResponseMessage> _responseFactory;
+
+            public CapturingMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> responseFactory)
+            {
+                _responseFactory = responseFactory;
+            }
+
+            public Uri RequestUri { get; private set; }
+
+            public string AuthorizationHeader { get; private set; }
+
+            public string RequestBody { get; private set; }
+
+            protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                RequestUri = request.RequestUri;
+                AuthorizationHeader = request.Headers.Authorization == null
+                    ? null
+                    : request.Headers.Authorization.Scheme + " " + request.Headers.Authorization.Parameter;
+                RequestBody = request.Content == null ? null : await request.Content.ReadAsStringAsync();
+                return _responseFactory(request);
+            }
+        }
+    }
+}

--- a/aspnet-core/test/AstraLab.Tests/Services/Datasets/DatasetProfilingManager_Tests.cs
+++ b/aspnet-core/test/AstraLab.Tests/Services/Datasets/DatasetProfilingManager_Tests.cs
@@ -1,0 +1,206 @@
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Abp.BackgroundJobs;
+using AstraLab.Core.Domains.Datasets;
+using AstraLab.Services.AI;
+using AstraLab.Services.Datasets;
+using AstraLab.Services.Datasets.Profiling;
+using AstraLab.Services.Datasets.Storage;
+using Castle.MicroKernel.Registration;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace AstraLab.Tests.Services.Datasets
+{
+    public class DatasetProfilingManager_Tests : AstraLabTestBase
+    {
+        private readonly IRawDatasetStorage _rawDatasetStorage;
+        private readonly IDatasetProfiler _datasetProfiler;
+        private readonly IBackgroundJobManager _backgroundJobManager;
+        private readonly IDatasetProfilingManager _datasetProfilingManager;
+
+        public DatasetProfilingManager_Tests()
+        {
+            _rawDatasetStorage = Substitute.For<IRawDatasetStorage>();
+            _datasetProfiler = Substitute.For<IDatasetProfiler>();
+            _backgroundJobManager = Substitute.For<IBackgroundJobManager>();
+
+            LocalIocManager.IocContainer.Register(
+                Component.For<IRawDatasetStorage>().Instance(_rawDatasetStorage).IsDefault().LifestyleSingleton(),
+                Component.For<IDatasetProfiler>().Instance(_datasetProfiler).IsDefault().LifestyleSingleton(),
+                Component.For<IBackgroundJobManager>().Instance(_backgroundJobManager).IsDefault().LifestyleSingleton());
+
+            _datasetProfilingManager = Resolve<IDatasetProfilingManager>();
+        }
+
+        [Fact]
+        public async Task ProfileAsync_Should_Enqueue_An_Automatic_Insight_Job_After_Successful_Profiling()
+        {
+            var datasetVersionId = UsingDbContext(context =>
+            {
+                var dataset = context.Datasets.Add(new Dataset
+                {
+                    TenantId = 1,
+                    Name = "profiling-success-dataset",
+                    Description = "profiling success dataset",
+                    SourceFormat = DatasetFormat.Csv,
+                    Status = DatasetStatus.Ready,
+                    OwnerUserId = AbpSession.UserId.Value,
+                    OriginalFileName = "profiling-success.csv"
+                }).Entity;
+
+                context.SaveChanges();
+
+                var datasetVersion = context.DatasetVersions.Add(new DatasetVersion
+                {
+                    TenantId = 1,
+                    DatasetId = dataset.Id,
+                    VersionNumber = 1,
+                    VersionType = DatasetVersionType.Raw,
+                    Status = DatasetVersionStatus.Active,
+                    RowCount = 5,
+                    ColumnCount = 1,
+                    SchemaJson = "{\"columns\":[{\"name\":\"amount\"}]}",
+                    SizeBytes = 256
+                }).Entity;
+
+                context.SaveChanges();
+
+                context.DatasetColumns.Add(new DatasetColumn
+                {
+                    TenantId = 1,
+                    DatasetVersionId = datasetVersion.Id,
+                    Name = "amount",
+                    DataType = "decimal",
+                    IsDataTypeInferred = true,
+                    Ordinal = 1
+                });
+
+                context.DatasetFiles.Add(new DatasetFile
+                {
+                    TenantId = 1,
+                    DatasetVersionId = datasetVersion.Id,
+                    StorageProvider = "local",
+                    StorageKey = "versions/1/raw/test.csv",
+                    OriginalFileName = "test.csv",
+                    SizeBytes = 128,
+                    ChecksumSha256 = new string('a', 64)
+                });
+
+                context.SaveChanges();
+                return datasetVersion.Id;
+            });
+
+            _rawDatasetStorage.OpenReadAsync(Arg.Any<OpenReadRawDatasetFileRequest>())
+                .Returns(Task.FromResult<Stream>(new MemoryStream(new byte[] { 1, 2, 3 })));
+            _datasetProfiler.ProfileAsync(Arg.Any<ProfileDatasetVersionRequest>())
+                .Returns(Task.FromResult(new ProfileDatasetVersionResult
+                {
+                    RowCount = 5,
+                    DuplicateRowCount = 1,
+                    DataHealthScore = 84.5m,
+                    SummaryJson = "{\"totalNullCount\":1,\"overallNullPercentage\":20.0,\"totalAnomalyCount\":0,\"overallAnomalyPercentage\":0.0}",
+                    Columns = new[]
+                    {
+                        new ProfiledDatasetColumnResult
+                        {
+                            DatasetColumnId = UsingDbContext(context => context.DatasetColumns.Single(item => item.DatasetVersionId == datasetVersionId).Id),
+                            InferredDataType = "decimal",
+                            NullCount = 1,
+                            DistinctCount = 4,
+                            StatisticsJson = "{\"nullPercentage\":20.0,\"anomalyCount\":0,\"anomalyPercentage\":0.0,\"hasAnomalies\":false}"
+                        }
+                    }
+                }));
+            _backgroundJobManager.EnqueueAsync<GenerateAutomaticDatasetInsightJob, GenerateAutomaticDatasetInsightJobArgs>(
+                    Arg.Any<GenerateAutomaticDatasetInsightJobArgs>(),
+                    Arg.Any<BackgroundJobPriority>(),
+                    Arg.Any<System.TimeSpan?>())
+                .Returns(Task.FromResult("job-1"));
+
+            await _datasetProfilingManager.ProfileAsync(datasetVersionId);
+
+            await _backgroundJobManager.Received(1).EnqueueAsync<GenerateAutomaticDatasetInsightJob, GenerateAutomaticDatasetInsightJobArgs>(
+                Arg.Is<GenerateAutomaticDatasetInsightJobArgs>(item =>
+                    item.DatasetVersionId == datasetVersionId &&
+                    item.TenantId == 1 &&
+                    item.OwnerUserId == AbpSession.UserId.Value &&
+                    item.DatasetProfileId > 0),
+                Arg.Any<BackgroundJobPriority>(),
+                Arg.Any<System.TimeSpan?>());
+        }
+
+        [Fact]
+        public async Task ProfileAsync_Should_Not_Enqueue_An_Automatic_Insight_Job_When_Profiling_Fails()
+        {
+            var datasetVersionId = UsingDbContext(context =>
+            {
+                var dataset = context.Datasets.Add(new Dataset
+                {
+                    TenantId = 1,
+                    Name = "profiling-failure-dataset",
+                    Description = "profiling failure dataset",
+                    SourceFormat = DatasetFormat.Csv,
+                    Status = DatasetStatus.Ready,
+                    OwnerUserId = AbpSession.UserId.Value,
+                    OriginalFileName = "profiling-failure.csv"
+                }).Entity;
+
+                context.SaveChanges();
+
+                var datasetVersion = context.DatasetVersions.Add(new DatasetVersion
+                {
+                    TenantId = 1,
+                    DatasetId = dataset.Id,
+                    VersionNumber = 1,
+                    VersionType = DatasetVersionType.Raw,
+                    Status = DatasetVersionStatus.Active,
+                    RowCount = 5,
+                    ColumnCount = 1,
+                    SchemaJson = "{\"columns\":[{\"name\":\"amount\"}]}",
+                    SizeBytes = 256
+                }).Entity;
+
+                context.SaveChanges();
+
+                context.DatasetColumns.Add(new DatasetColumn
+                {
+                    TenantId = 1,
+                    DatasetVersionId = datasetVersion.Id,
+                    Name = "amount",
+                    DataType = "decimal",
+                    IsDataTypeInferred = true,
+                    Ordinal = 1
+                });
+
+                context.DatasetFiles.Add(new DatasetFile
+                {
+                    TenantId = 1,
+                    DatasetVersionId = datasetVersion.Id,
+                    StorageProvider = "local",
+                    StorageKey = "versions/2/raw/test.csv",
+                    OriginalFileName = "test.csv",
+                    SizeBytes = 128,
+                    ChecksumSha256 = new string('b', 64)
+                });
+
+                context.SaveChanges();
+                return datasetVersion.Id;
+            });
+
+            _rawDatasetStorage.OpenReadAsync(Arg.Any<OpenReadRawDatasetFileRequest>())
+                .Returns(Task.FromResult<Stream>(new MemoryStream(new byte[] { 1, 2, 3 })));
+            _datasetProfiler.ProfileAsync(Arg.Any<ProfileDatasetVersionRequest>())
+                .Returns<Task<ProfileDatasetVersionResult>>(_ => throw new InvalidDataException("Profile failure."));
+
+            await Should.ThrowAsync<InvalidDataException>(() => _datasetProfilingManager.ProfileAsync(datasetVersionId));
+
+            await _backgroundJobManager.DidNotReceive().EnqueueAsync<GenerateAutomaticDatasetInsightJob, GenerateAutomaticDatasetInsightJobArgs>(
+                Arg.Any<GenerateAutomaticDatasetInsightJobArgs>(),
+                Arg.Any<BackgroundJobPriority>(),
+                Arg.Any<System.TimeSpan?>());
+        }
+    }
+}

--- a/aspnet-core/test/AstraLab.Tests/Services/ML/MLExperimentAppService_Tests.cs
+++ b/aspnet-core/test/AstraLab.Tests/Services/ML/MLExperimentAppService_Tests.cs
@@ -2,14 +2,17 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Abp.Application.Services.Dto;
+using Abp.BackgroundJobs;
 using Abp.Domain.Entities;
 using Abp.Runtime.Session;
 using Abp.UI;
 using AstraLab.Core.Domains.Datasets;
 using AstraLab.Core.Domains.ML;
 using AstraLab.MultiTenancy;
+using AstraLab.Services.AI;
 using AstraLab.Services.ML;
 using AstraLab.Services.ML.Dto;
+using Castle.MicroKernel.Registration;
 using NSubstitute;
 using Shouldly;
 using Xunit;
@@ -20,14 +23,26 @@ namespace AstraLab.Tests.Services.ML
     {
         private readonly IMLExperimentAppService _mlExperimentAppService;
         private readonly IMLExperimentExecutionManager _mlExperimentExecutionManager;
+        private readonly IBackgroundJobManager _backgroundJobManager;
         private readonly IMLJobDispatcher _mlJobDispatcher;
 
         public MLExperimentAppService_Tests()
         {
+            _backgroundJobManager = Substitute.For<IBackgroundJobManager>();
+            _mlJobDispatcher = Resolve<IMLJobDispatcher>();
+            LocalIocManager.IocContainer.Register(
+                Component.For<IBackgroundJobManager>()
+                    .Instance(_backgroundJobManager)
+                    .IsDefault()
+                    .LifestyleSingleton());
             _mlExperimentAppService = Resolve<IMLExperimentAppService>();
             _mlExperimentExecutionManager = Resolve<IMLExperimentExecutionManager>();
-            _mlJobDispatcher = Resolve<IMLJobDispatcher>();
             _mlJobDispatcher.DispatchAsync(Arg.Any<DispatchMlExperimentRequest>()).Returns(Task.CompletedTask);
+            _backgroundJobManager.EnqueueAsync<GenerateAutomaticExperimentInsightJob, GenerateAutomaticExperimentInsightJobArgs>(
+                    Arg.Any<GenerateAutomaticExperimentInsightJobArgs>(),
+                    Arg.Any<BackgroundJobPriority>(),
+                    Arg.Any<TimeSpan?>())
+                .Returns(Task.FromResult("ml-ai-job-1"));
         }
 
         [Fact]
@@ -268,6 +283,15 @@ namespace AstraLab.Tests.Services.ML
                 context.MLModelFeatureImportances.Count(item => item.MLModelId == model.Id).ShouldBe(2);
                 await Task.CompletedTask;
             });
+
+            await _backgroundJobManager.Received(1).EnqueueAsync<GenerateAutomaticExperimentInsightJob, GenerateAutomaticExperimentInsightJobArgs>(
+                Arg.Is<GenerateAutomaticExperimentInsightJobArgs>(item =>
+                    item.MLExperimentId == experimentId &&
+                    item.DatasetVersionId == seeded.DatasetVersionId &&
+                    item.TenantId == 1 &&
+                    item.OwnerUserId == AbpSession.GetUserId()),
+                Arg.Any<BackgroundJobPriority>(),
+                Arg.Any<TimeSpan?>());
         }
 
         [Fact]
@@ -300,6 +324,11 @@ namespace AstraLab.Tests.Services.ML
                 context.MLModels.Count(item => item.MLExperimentId == experimentId).ShouldBe(0);
                 await Task.CompletedTask;
             });
+
+            await _backgroundJobManager.DidNotReceive().EnqueueAsync<GenerateAutomaticExperimentInsightJob, GenerateAutomaticExperimentInsightJobArgs>(
+                Arg.Any<GenerateAutomaticExperimentInsightJobArgs>(),
+                Arg.Any<BackgroundJobPriority>(),
+                Arg.Any<TimeSpan?>());
         }
 
         [Fact]

--- a/frontend/src/app/(protected)/datasets/[datasetId]/assistant/page.tsx
+++ b/frontend/src/app/(protected)/datasets/[datasetId]/assistant/page.tsx
@@ -1,0 +1,278 @@
+"use client";
+
+import { useEffect, useEffectEvent } from "react";
+import { Button, Card } from "antd";
+import { useParams, useRouter, useSearchParams } from "next/navigation";
+import { DatasetAiAssistantWorkspace } from "@/components/datasets/ai/datasetAiAssistantWorkspace";
+import { DatasetOverviewCard } from "@/components/datasets/details/datasetOverviewCard";
+import { DatasetVersionSelector } from "@/components/datasets/details/datasetVersionSelector";
+import { DatasetProfileSummaryCard } from "@/components/datasets/shared/datasetProfileSummaryCard";
+import { DatasetErrorState } from "@/components/datasets/shared/datasetErrorState";
+import { WorkspacePageHeader } from "@/components/workspaceShell/WorkspacePageHeader";
+import {
+  DatasetAiAssistantProvider,
+  useDatasetAiAssistantActions,
+  useDatasetAiAssistantState,
+} from "@/providers/datasetAiAssistantProvider";
+import {
+  DatasetDetailsProvider,
+  useDatasetDetailsActions,
+  useDatasetDetailsState,
+} from "@/providers/datasetDetailsProvider";
+import { getDatasetProfileOverview } from "@/utils/datasets";
+import { useStyles } from "./style";
+
+const DEFAULT_CONVERSATION_PAGE_SIZE = 20;
+const DEFAULT_RESPONSE_PAGE_SIZE = 100;
+
+const parseRouteNumber = (value: string | null | undefined): number | undefined => {
+  const parsedValue = Number(value);
+
+  if (!Number.isFinite(parsedValue) || parsedValue <= 0) {
+    return undefined;
+  }
+
+  return parsedValue;
+};
+
+const DatasetAssistantContent = () => {
+  const { styles } = useStyles();
+  const router = useRouter();
+  const params = useParams<{ datasetId: string }>();
+  const searchParams = useSearchParams();
+  const { details, errorMessage, isError, isLoadingDetails } =
+    useDatasetDetailsState();
+  const { getDatasetDetails, refreshDetails } = useDatasetDetailsActions();
+  const {
+    activeConversationId,
+    activeDatasetVersionId,
+    conversationErrorMessage,
+    conversations,
+    generationErrorMessage,
+    isGenerating,
+    isLoadingConversations,
+    isLoadingResponses,
+    responseErrorMessage,
+    responses,
+  } = useDatasetAiAssistantState();
+  const {
+    askQuestion,
+    clearConversationState,
+    generateCleaningRecommendations,
+    generateInsights,
+    generateSummary,
+    getConversations,
+    getResponses,
+    setActiveConversation,
+  } = useDatasetAiAssistantActions();
+
+  const datasetId = parseRouteNumber(params.datasetId);
+  const selectedVersionId = parseRouteNumber(searchParams.get("versionId"));
+  const effectiveSelectedVersionId =
+    selectedVersionId ?? details?.selectedVersion?.id;
+
+  const loadDetails = useEffectEvent(() => {
+    if (!datasetId) {
+      return;
+    }
+
+    void getDatasetDetails(datasetId, selectedVersionId);
+  });
+
+  useEffect(() => {
+    loadDetails();
+  }, [datasetId, selectedVersionId]);
+
+  const loadConversations = useEffectEvent(() => {
+    if (!datasetId || !effectiveSelectedVersionId) {
+      clearConversationState();
+      return;
+    }
+
+    void getConversations({
+      datasetId,
+      datasetVersionId: effectiveSelectedVersionId,
+      page: 1,
+      pageSize: DEFAULT_CONVERSATION_PAGE_SIZE,
+    });
+  });
+
+  useEffect(() => {
+    loadConversations();
+  }, [datasetId, effectiveSelectedVersionId]);
+
+  useEffect(() => {
+    if (conversations.length === 0) {
+      if (activeConversationId) {
+        setActiveConversation(undefined);
+      }
+
+      return;
+    }
+
+    const activeConversationStillVisible = conversations.some(
+      (conversation) => conversation.id === activeConversationId,
+    );
+
+    if (!activeConversationStillVisible) {
+      setActiveConversation(conversations[0]?.id);
+    }
+  }, [activeConversationId, conversations, setActiveConversation]);
+
+  const loadResponses = useEffectEvent(() => {
+    if (!activeConversationId) {
+      return;
+    }
+
+    void getResponses({
+      conversationId: activeConversationId,
+      page: 1,
+      pageSize: DEFAULT_RESPONSE_PAGE_SIZE,
+      isChronological: true,
+    });
+  });
+
+  useEffect(() => {
+    loadResponses();
+  }, [activeConversationId]);
+
+  const handleVersionChange = (versionId?: number) => {
+    if (!datasetId) {
+      return;
+    }
+
+    clearConversationState();
+
+    const nextSearchParams = new URLSearchParams(searchParams.toString());
+
+    if (versionId) {
+      nextSearchParams.set("versionId", String(versionId));
+    } else {
+      nextSearchParams.delete("versionId");
+    }
+
+    const queryString = nextSearchParams.toString();
+    router.push(
+      queryString
+        ? `/datasets/${datasetId}/assistant?${queryString}`
+        : `/datasets/${datasetId}/assistant`,
+    );
+  };
+
+  if (!datasetId) {
+    return (
+      <DatasetErrorState
+        title="Invalid dataset route"
+        message="The dataset identifier in the URL is not valid."
+        action={
+          <Button type="primary" onClick={() => router.push("/datasets")}>
+            Back to datasets
+          </Button>
+        }
+      />
+    );
+  }
+
+  const profileOverview = getDatasetProfileOverview(details?.selectedVersion?.profile);
+  const datasetDetailsHref = effectiveSelectedVersionId
+    ? `/datasets/${datasetId}?versionId=${effectiveSelectedVersionId}`
+    : `/datasets/${datasetId}`;
+
+  return (
+    <>
+      <WorkspacePageHeader
+        title={details?.dataset.name || "Dataset AI Assistant"}
+        description="Ask grounded questions, generate summaries, and revisit stored assistant threads for the selected dataset version."
+        actions={
+          <div className={styles.actionGroup}>
+            <Button size="large" onClick={() => router.push(datasetDetailsHref)}>
+              Back to details
+            </Button>
+            <Button size="large" onClick={() => router.push("/datasets")}>
+              Back to datasets
+            </Button>
+          </div>
+        }
+      />
+
+      {isError && !details ? (
+        <DatasetErrorState
+          title="Unable to load dataset details"
+          message={errorMessage || "Please try again in a moment."}
+          action={
+            <Button type="primary" onClick={() => void refreshDetails()}>
+              Retry
+            </Button>
+          }
+        />
+      ) : null}
+
+      {!details && !isError ? <Card loading className={styles.loadingCard} /> : null}
+
+      {details ? (
+        <div className={styles.pageGrid}>
+          <div className={styles.mainColumn}>
+            <DatasetAiAssistantWorkspace
+              datasetVersionId={activeDatasetVersionId ?? effectiveSelectedVersionId}
+              activeConversationId={activeConversationId}
+              conversations={conversations}
+              responses={responses}
+              isLoadingConversations={isLoadingConversations}
+              isLoadingResponses={isLoadingResponses}
+              isGenerating={isGenerating}
+              conversationErrorMessage={conversationErrorMessage}
+              responseErrorMessage={responseErrorMessage}
+              generationErrorMessage={generationErrorMessage}
+              onSelectConversation={setActiveConversation}
+              onGenerateSummary={generateSummary}
+              onGenerateInsights={generateInsights}
+              onGenerateRecommendations={generateCleaningRecommendations}
+              onAskQuestion={(question) => {
+                const datasetVersionId =
+                  activeDatasetVersionId ?? effectiveSelectedVersionId;
+
+                if (!datasetVersionId) {
+                  return Promise.resolve();
+                }
+
+                return askQuestion({
+                  datasetVersionId,
+                  question,
+                  conversationId: activeConversationId,
+                });
+              }}
+            />
+          </div>
+
+          <div className={styles.sideColumn}>
+            <DatasetVersionSelector
+              versions={details.versions}
+              selectedVersionId={effectiveSelectedVersionId}
+              onChange={handleVersionChange}
+            />
+            <DatasetOverviewCard
+              dataset={details.dataset}
+              selectedVersion={details.selectedVersion}
+            />
+            <DatasetProfileSummaryCard
+              profile={profileOverview}
+              isLoading={isLoadingDetails}
+              title="Selected Version Context"
+              emptyDescription="Profiling context for the selected version will appear here when it is available."
+            />
+          </div>
+        </div>
+      ) : null}
+    </>
+  );
+};
+
+const DatasetAssistantPage = () => (
+  <DatasetAiAssistantProvider>
+    <DatasetDetailsProvider>
+      <DatasetAssistantContent />
+    </DatasetDetailsProvider>
+  </DatasetAiAssistantProvider>
+);
+
+export default DatasetAssistantPage;

--- a/frontend/src/app/(protected)/datasets/[datasetId]/assistant/page.tsx
+++ b/frontend/src/app/(protected)/datasets/[datasetId]/assistant/page.tsx
@@ -45,11 +45,15 @@ const DatasetAssistantContent = () => {
   const { getDatasetDetails, refreshDetails } = useDatasetDetailsActions();
   const {
     activeConversationId,
+    activeExperiment,
     activeDatasetVersionId,
+    activeMlExperimentId,
     conversationErrorMessage,
     conversations,
+    experimentContextErrorMessage,
     generationErrorMessage,
     isGenerating,
+    isLoadingExperimentContext,
     isLoadingConversations,
     isLoadingResponses,
     responseErrorMessage,
@@ -63,13 +67,16 @@ const DatasetAssistantContent = () => {
     generateSummary,
     getConversations,
     getResponses,
+    loadExperimentContext,
     setActiveConversation,
   } = useDatasetAiAssistantActions();
 
   const datasetId = parseRouteNumber(params.datasetId);
   const selectedVersionId = parseRouteNumber(searchParams.get("versionId"));
+  const selectedExperimentId = parseRouteNumber(searchParams.get("experimentId"));
   const effectiveSelectedVersionId =
     selectedVersionId ?? details?.selectedVersion?.id;
+  const effectiveExperimentId = activeMlExperimentId ?? selectedExperimentId;
 
   const loadDetails = useEffectEvent(() => {
     if (!datasetId) {
@@ -83,15 +90,28 @@ const DatasetAssistantContent = () => {
     loadDetails();
   }, [datasetId, selectedVersionId]);
 
+  const loadExperiment = useEffectEvent(() => {
+    void loadExperimentContext(selectedExperimentId);
+  });
+
+  useEffect(() => {
+    loadExperiment();
+  }, [selectedExperimentId]);
+
   const loadConversations = useEffectEvent(() => {
-    if (!datasetId || !effectiveSelectedVersionId) {
+    if (!datasetId) {
       clearConversationState();
+      return;
+    }
+
+    if (!effectiveSelectedVersionId) {
       return;
     }
 
     void getConversations({
       datasetId,
       datasetVersionId: effectiveSelectedVersionId,
+      mlExperimentId: effectiveExperimentId,
       page: 1,
       pageSize: DEFAULT_CONVERSATION_PAGE_SIZE,
     });
@@ -99,7 +119,31 @@ const DatasetAssistantContent = () => {
 
   useEffect(() => {
     loadConversations();
-  }, [datasetId, effectiveSelectedVersionId]);
+  }, [datasetId, effectiveExperimentId, effectiveSelectedVersionId]);
+
+  useEffect(() => {
+    if (!datasetId || !activeExperiment) {
+      return;
+    }
+
+    if (activeExperiment.datasetVersionId === effectiveSelectedVersionId) {
+      return;
+    }
+
+    const nextSearchParams = new URLSearchParams(searchParams.toString());
+    nextSearchParams.set("versionId", String(activeExperiment.datasetVersionId));
+    nextSearchParams.set("experimentId", String(activeExperiment.id));
+
+    router.replace(`/datasets/${datasetId}/assistant?${nextSearchParams.toString()}`, {
+      scroll: false,
+    });
+  }, [
+    activeExperiment,
+    datasetId,
+    effectiveSelectedVersionId,
+    router,
+    searchParams,
+  ]);
 
   useEffect(() => {
     if (conversations.length === 0) {
@@ -151,6 +195,8 @@ const DatasetAssistantContent = () => {
       nextSearchParams.delete("versionId");
     }
 
+    nextSearchParams.delete("experimentId");
+
     const queryString = nextSearchParams.toString();
     router.push(
       queryString
@@ -177,12 +223,15 @@ const DatasetAssistantContent = () => {
   const datasetDetailsHref = effectiveSelectedVersionId
     ? `/datasets/${datasetId}?versionId=${effectiveSelectedVersionId}`
     : `/datasets/${datasetId}`;
+  const assistantDescription = activeExperiment
+    ? "Ask grounded questions about the selected ML experiment, explain results in plain language, and revisit stored assistant threads anchored to this run."
+    : "Ask grounded questions, generate summaries, and revisit stored assistant threads for the selected dataset version.";
 
   return (
     <>
       <WorkspacePageHeader
         title={details?.dataset.name || "Dataset AI Assistant"}
-        description="Ask grounded questions, generate summaries, and revisit stored assistant threads for the selected dataset version."
+        description={assistantDescription}
         actions={
           <div className={styles.actionGroup}>
             <Button size="large" onClick={() => router.push(datasetDetailsHref)}>
@@ -214,18 +263,33 @@ const DatasetAssistantContent = () => {
           <div className={styles.mainColumn}>
             <DatasetAiAssistantWorkspace
               datasetVersionId={activeDatasetVersionId ?? effectiveSelectedVersionId}
+              experiment={activeExperiment}
               activeConversationId={activeConversationId}
               conversations={conversations}
               responses={responses}
+              isLoadingExperimentContext={isLoadingExperimentContext}
               isLoadingConversations={isLoadingConversations}
               isLoadingResponses={isLoadingResponses}
               isGenerating={isGenerating}
+              experimentContextErrorMessage={experimentContextErrorMessage}
               conversationErrorMessage={conversationErrorMessage}
               responseErrorMessage={responseErrorMessage}
               generationErrorMessage={generationErrorMessage}
               onSelectConversation={setActiveConversation}
               onGenerateSummary={generateSummary}
-              onGenerateInsights={generateInsights}
+              onGenerateInsights={(datasetVersionId) => {
+                if (activeExperiment) {
+                  return askQuestion({
+                    datasetVersionId,
+                    mlExperimentId: activeExperiment.id,
+                    question:
+                      "Explain these experiment results in plain language and highlight the most important signals.",
+                    conversationId: activeConversationId,
+                  });
+                }
+
+                return generateInsights(datasetVersionId);
+              }}
               onGenerateRecommendations={generateCleaningRecommendations}
               onAskQuestion={(question) => {
                 const datasetVersionId =
@@ -239,6 +303,7 @@ const DatasetAssistantContent = () => {
                   datasetVersionId,
                   question,
                   conversationId: activeConversationId,
+                  mlExperimentId: activeMlExperimentId,
                 });
               }}
             />

--- a/frontend/src/app/(protected)/datasets/[datasetId]/assistant/style.ts
+++ b/frontend/src/app/(protected)/datasets/[datasetId]/assistant/style.ts
@@ -1,0 +1,41 @@
+"use client";
+
+import { createStyles } from "antd-style";
+
+export const useStyles = createStyles(({ css }) => ({
+  pageGrid: css`
+    display: grid;
+    grid-template-columns: minmax(0, 1.55fr) minmax(300px, 0.95fr);
+    gap: 24px;
+
+    @media (max-width: 1180px) {
+      grid-template-columns: minmax(0, 1fr);
+    }
+  `,
+
+  mainColumn: css`
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+  `,
+
+  sideColumn: css`
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+  `,
+
+  actionGroup: css`
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+  `,
+
+  loadingCard: css`
+    &.ant-card {
+      min-height: 280px;
+      border-radius: 24px;
+    }
+  `,
+}));

--- a/frontend/src/app/(protected)/datasets/[datasetId]/page.tsx
+++ b/frontend/src/app/(protected)/datasets/[datasetId]/page.tsx
@@ -7,8 +7,10 @@ import { DatasetProfileSummaryCard } from "@/components/datasets/shared/datasetP
 import { DatasetProfileColumnsTable } from "@/components/datasets/shared/datasetProfileColumnsTable";
 import { WorkspacePageHeader } from "@/components/workspaceShell/WorkspacePageHeader";
 import { DatasetOverviewCard } from "@/components/datasets/details/datasetOverviewCard";
+import { DatasetAutomaticInsightCard } from "@/components/datasets/details/datasetAutomaticInsightCard";
 import { DatasetVersionSelector } from "@/components/datasets/details/datasetVersionSelector";
 import { RawFileSummaryCard } from "@/components/datasets/details/rawFileSummaryCard";
+import { DatasetAiAssistantLauncherButton } from "@/components/datasets/ai/datasetAiAssistantLauncherButton";
 import { DatasetColumnsTable } from "@/components/datasets/shared/datasetColumnsTable";
 import { DatasetErrorState } from "@/components/datasets/shared/datasetErrorState";
 import { DatasetSchemaPreview } from "@/components/datasets/shared/datasetSchemaPreview";
@@ -16,6 +18,11 @@ import { DatasetTransformationHistoryCard } from "@/components/datasets/transfor
 import { MlWorkspaceLauncherCard } from "@/components/datasets/ml/mlWorkspaceLauncherCard";
 import { DatasetExplorationLauncherButton } from "@/components/datasets/exploration/datasetExplorationLauncherButton";
 import { DEFAULT_DATASET_PROFILE_COLUMNS_PAGE_SIZE } from "@/constants/datasets";
+import {
+  DatasetAutoInsightProvider,
+  useDatasetAutoInsightActions,
+  useDatasetAutoInsightState,
+} from "@/providers/datasetAutoInsightProvider";
 import {
   DatasetDetailsProvider,
   useDatasetDetailsActions,
@@ -65,6 +72,17 @@ const DatasetDetailsContent = () => {
     profileColumnsErrorMessage,
     profileColumnsTotalCount,
   } = useDatasetDetailsState();
+  const {
+    clearLatestAutomaticInsight,
+    getLatestAutomaticInsight,
+    refreshLatestAutomaticInsight,
+  } = useDatasetAutoInsightActions();
+  const {
+    errorMessage: autoInsightErrorMessage,
+    isError: isAutoInsightError,
+    isLoading: isLoadingAutoInsight,
+    latestInsight,
+  } = useDatasetAutoInsightState();
   const {
     getTransformationHistory,
     refreshTransformationHistory,
@@ -133,6 +151,19 @@ const DatasetDetailsContent = () => {
     profileColumnsPage,
     profileColumnsPageSize,
   ]);
+
+  const loadAutomaticInsight = useEffectEvent(() => {
+    if (!selectedVersionDetailsId) {
+      clearLatestAutomaticInsight();
+      return;
+    }
+
+    void getLatestAutomaticInsight(selectedVersionDetailsId);
+  });
+
+  useEffect(() => {
+    loadAutomaticInsight();
+  }, [selectedVersionDetailsId]);
 
   const handleVersionChange = (versionId?: number) => {
     if (!datasetId) {
@@ -208,6 +239,11 @@ const DatasetDetailsContent = () => {
               versionId={effectiveSelectedVersionId}
               size="large"
             />
+            <DatasetAiAssistantLauncherButton
+              datasetId={datasetId}
+              versionId={effectiveSelectedVersionId}
+              size="large"
+            />
             <Button
               type="primary"
               size="large"
@@ -257,6 +293,13 @@ const DatasetDetailsContent = () => {
               isLoading={isLoadingDetails}
               title="Profiling Summary"
               emptyDescription="Profiling insights will appear here when they are available for the selected version."
+            />
+            <DatasetAutomaticInsightCard
+              insight={latestInsight}
+              isLoading={isLoadingAutoInsight}
+              isError={isAutoInsightError}
+              errorMessage={autoInsightErrorMessage}
+              onRetry={() => void refreshLatestAutomaticInsight()}
             />
             <DatasetSchemaPreview
               schemaJson={details.selectedVersion?.schemaJson}
@@ -344,9 +387,11 @@ const DatasetDetailsContent = () => {
 
 const DatasetDetailsPage = () => (
   <DatasetTransformationHistoryProvider>
-    <DatasetDetailsProvider>
-      <DatasetDetailsContent />
-    </DatasetDetailsProvider>
+    <DatasetAutoInsightProvider>
+      <DatasetDetailsProvider>
+        <DatasetDetailsContent />
+      </DatasetDetailsProvider>
+    </DatasetAutoInsightProvider>
   </DatasetTransformationHistoryProvider>
 );
 

--- a/frontend/src/app/(protected)/ml-workspace/page.tsx
+++ b/frontend/src/app/(protected)/ml-workspace/page.tsx
@@ -22,6 +22,7 @@ import {
   useDatasetDetailsActions,
   useDatasetDetailsState,
 } from "@/providers/datasetDetailsProvider";
+import { MlExperimentAutoInsightProvider } from "@/providers/mlExperimentAutoInsightProvider";
 import { MlExperimentsProvider } from "@/providers/mlExperimentsProvider";
 import { formatDateTime, getDatasetVersionTypeLabel } from "@/utils/datasets";
 import { buildMlWorkspaceHref } from "@/utils/ml";
@@ -60,7 +61,6 @@ const MlWorkspacePageContent = () => {
     isLoadingDetails,
   } = useDatasetDetailsState();
   const [datasetKeyword, setDatasetKeyword] = useState("");
-  const [selectionMessage, setSelectionMessage] = useState<string>();
   const deferredDatasetKeyword = useDeferredValue(datasetKeyword);
 
   const datasetId = parseQueryNumber(searchParams.get("datasetId"));
@@ -90,7 +90,6 @@ const MlWorkspacePageContent = () => {
 
   useEffect(() => {
     if (!datasetId) {
-      setSelectionMessage(undefined);
       return;
     }
 
@@ -110,9 +109,6 @@ const MlWorkspacePageContent = () => {
     if (versionId && !selectedVersionIds.includes(versionId)) {
       const fallbackVersionId = currentDetails.selectedVersion?.id;
 
-      setSelectionMessage(
-        "The selected version does not belong to this dataset, so the workspace switched to the default version.",
-      );
       router.replace(buildMlWorkspaceHref(datasetId, fallbackVersionId), {
         scroll: false,
       });
@@ -128,8 +124,6 @@ const MlWorkspacePageContent = () => {
       );
       return;
     }
-
-    setSelectionMessage(undefined);
   }, [currentDetails, datasetId, router, selectedVersionIds, versionId]);
 
   const datasetOptions = useMemo(() => {
@@ -152,7 +146,7 @@ const MlWorkspacePageContent = () => {
     return Array.from(optionMap.values()).sort((left, right) =>
       left.label.localeCompare(right.label),
     );
-  }, [currentDetails?.dataset, datasets]);
+  }, [currentDetails, datasets]);
 
   const versionOptions = useMemo(
     () =>
@@ -170,7 +164,6 @@ const MlWorkspacePageContent = () => {
     : undefined;
 
   const handleDatasetChange = (nextDatasetId?: number) => {
-    setSelectionMessage(undefined);
     router.push(buildMlWorkspaceHref(nextDatasetId));
   };
 
@@ -179,7 +172,6 @@ const MlWorkspacePageContent = () => {
       return;
     }
 
-    setSelectionMessage(undefined);
     router.push(buildMlWorkspaceHref(datasetId, nextVersionId));
   };
 
@@ -216,7 +208,7 @@ const MlWorkspacePageContent = () => {
                 notFoundContent={
                   isLoadingCatalog ? "Loading datasets..." : "No datasets found."
                 }
-                style={{ marginTop: 8, width: "100%" }}
+                className={styles.selectInput}
               />
             </div>
 
@@ -234,7 +226,7 @@ const MlWorkspacePageContent = () => {
                 options={versionOptions}
                 disabled={!datasetId || !hasVersions || isLoadingDetails}
                 onChange={handleVersionChange}
-                style={{ marginTop: 8, width: "100%" }}
+                className={styles.selectInput}
               />
             </div>
           </div>
@@ -249,10 +241,6 @@ const MlWorkspacePageContent = () => {
             </Paragraph>
           ) : null}
         </Card>
-
-        {selectionMessage ? (
-          <Alert type="warning" showIcon message={selectionMessage} />
-        ) : null}
 
         {isDatasetCatalogError ? (
           <Alert
@@ -308,6 +296,7 @@ const MlWorkspacePageContent = () => {
 
         {datasetId && currentDetails && hasVersions ? (
           <MlExperimentWorkspace
+            datasetId={currentDetails.dataset.id}
             datasetVersionId={effectiveSelectedVersionId}
             columns={currentDetails.columns}
             hasRawFile={Boolean(currentDetails.selectedVersion?.rawFile)}
@@ -322,7 +311,9 @@ const MlWorkspacePage = () => (
   <DatasetCatalogProvider>
     <DatasetDetailsProvider>
       <MlExperimentsProvider>
-        <MlWorkspacePageContent />
+        <MlExperimentAutoInsightProvider>
+          <MlWorkspacePageContent />
+        </MlExperimentAutoInsightProvider>
       </MlExperimentsProvider>
     </DatasetDetailsProvider>
   </DatasetCatalogProvider>

--- a/frontend/src/app/(protected)/ml-workspace/style.ts
+++ b/frontend/src/app/(protected)/ml-workspace/style.ts
@@ -41,6 +41,11 @@ export const useStyles = createStyles(({ css, token }) => ({
     color: ${token.colorTextSecondary};
   `,
 
+  selectInput: css`
+    width: 100%;
+    margin-top: 8px;
+  `,
+
   loadingCard: css`
     &.ant-card {
       min-height: 280px;

--- a/frontend/src/components/datasets/ai/datasetAiAssistantLauncherButton/index.tsx
+++ b/frontend/src/components/datasets/ai/datasetAiAssistantLauncherButton/index.tsx
@@ -7,26 +7,36 @@ import { useRouter } from "next/navigation";
 interface DatasetAiAssistantLauncherButtonProps extends ButtonProps {
   datasetId: number;
   versionId?: number;
+  experimentId?: number;
 }
 
 export const DatasetAiAssistantLauncherButton = ({
   datasetId,
   versionId,
+  experimentId,
   children = "AI assistant",
   ...buttonProps
 }: DatasetAiAssistantLauncherButtonProps) => {
   const router = useRouter();
 
+  const searchParams = new URLSearchParams();
+
+  if (versionId) {
+    searchParams.set("versionId", String(versionId));
+  }
+
+  if (experimentId) {
+    searchParams.set("experimentId", String(experimentId));
+  }
+
+  const href = searchParams.toString()
+    ? `/datasets/${datasetId}/assistant?${searchParams.toString()}`
+    : `/datasets/${datasetId}/assistant`;
+
   return (
     <Button
       {...buttonProps}
-      onClick={() =>
-        router.push(
-          versionId
-            ? `/datasets/${datasetId}/assistant?versionId=${versionId}`
-            : `/datasets/${datasetId}/assistant`,
-        )
-      }
+      onClick={() => router.push(href)}
     >
       {children}
     </Button>

--- a/frontend/src/components/datasets/ai/datasetAiAssistantLauncherButton/index.tsx
+++ b/frontend/src/components/datasets/ai/datasetAiAssistantLauncherButton/index.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { Button } from "antd";
+import type { ButtonProps } from "antd";
+import { useRouter } from "next/navigation";
+
+interface DatasetAiAssistantLauncherButtonProps extends ButtonProps {
+  datasetId: number;
+  versionId?: number;
+}
+
+export const DatasetAiAssistantLauncherButton = ({
+  datasetId,
+  versionId,
+  children = "AI assistant",
+  ...buttonProps
+}: DatasetAiAssistantLauncherButtonProps) => {
+  const router = useRouter();
+
+  return (
+    <Button
+      {...buttonProps}
+      onClick={() =>
+        router.push(
+          versionId
+            ? `/datasets/${datasetId}/assistant?versionId=${versionId}`
+            : `/datasets/${datasetId}/assistant`,
+        )
+      }
+    >
+      {children}
+    </Button>
+  );
+};

--- a/frontend/src/components/datasets/ai/datasetAiAssistantWorkspace/index.tsx
+++ b/frontend/src/components/datasets/ai/datasetAiAssistantWorkspace/index.tsx
@@ -2,7 +2,9 @@
 
 import { Alert } from "antd";
 import type { AIConversation, AIResponse } from "@/types/datasets";
+import type { MlExperiment } from "@/types/ml";
 import { DatasetAiConversationListCard } from "../datasetAiConversationListCard";
+import { DatasetAiExperimentContextCard } from "../datasetAiExperimentContextCard";
 import { DatasetAiPromptComposer } from "../datasetAiPromptComposer";
 import { DatasetAiQuickActionsCard } from "../datasetAiQuickActionsCard";
 import { DatasetAiResponseThreadCard } from "../datasetAiResponseThreadCard";
@@ -10,12 +12,15 @@ import { useStyles } from "./style";
 
 interface DatasetAiAssistantWorkspaceProps {
   datasetVersionId?: number;
+  experiment?: MlExperiment;
   activeConversationId?: number;
   conversations: AIConversation[];
   responses: AIResponse[];
+  isLoadingExperimentContext?: boolean;
   isLoadingConversations?: boolean;
   isLoadingResponses?: boolean;
   isGenerating?: boolean;
+  experimentContextErrorMessage?: string;
   conversationErrorMessage?: string;
   responseErrorMessage?: string;
   generationErrorMessage?: string;
@@ -28,12 +33,15 @@ interface DatasetAiAssistantWorkspaceProps {
 
 export const DatasetAiAssistantWorkspace = ({
   datasetVersionId,
+  experiment,
   activeConversationId,
   conversations,
   responses,
+  isLoadingExperimentContext = false,
   isLoadingConversations = false,
   isLoadingResponses = false,
   isGenerating = false,
+  experimentContextErrorMessage,
   conversationErrorMessage,
   responseErrorMessage,
   generationErrorMessage,
@@ -44,13 +52,21 @@ export const DatasetAiAssistantWorkspace = ({
   onAskQuestion,
 }: DatasetAiAssistantWorkspaceProps) => {
   const { styles } = useStyles();
+  const isExperimentScoped = Boolean(experiment);
 
   return (
     <div className={styles.layout}>
       <div className={styles.sideColumn}>
+        <DatasetAiExperimentContextCard
+          experiment={experiment}
+          isLoading={isLoadingExperimentContext}
+          isError={Boolean(experimentContextErrorMessage)}
+          errorMessage={experimentContextErrorMessage}
+        />
         <DatasetAiConversationListCard
           conversations={conversations}
           activeConversationId={activeConversationId}
+          isExperimentScoped={isExperimentScoped}
           isLoading={isLoadingConversations}
           isError={Boolean(conversationErrorMessage)}
           errorMessage={conversationErrorMessage}
@@ -70,6 +86,7 @@ export const DatasetAiAssistantWorkspace = ({
 
         <DatasetAiQuickActionsCard
           datasetVersionId={datasetVersionId}
+          isExperimentScoped={isExperimentScoped}
           isLoading={isGenerating}
           onGenerateSummary={onGenerateSummary}
           onGenerateInsights={onGenerateInsights}

--- a/frontend/src/components/datasets/ai/datasetAiAssistantWorkspace/index.tsx
+++ b/frontend/src/components/datasets/ai/datasetAiAssistantWorkspace/index.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { Alert } from "antd";
+import type { AIConversation, AIResponse } from "@/types/datasets";
+import { DatasetAiConversationListCard } from "../datasetAiConversationListCard";
+import { DatasetAiPromptComposer } from "../datasetAiPromptComposer";
+import { DatasetAiQuickActionsCard } from "../datasetAiQuickActionsCard";
+import { DatasetAiResponseThreadCard } from "../datasetAiResponseThreadCard";
+import { useStyles } from "./style";
+
+interface DatasetAiAssistantWorkspaceProps {
+  datasetVersionId?: number;
+  activeConversationId?: number;
+  conversations: AIConversation[];
+  responses: AIResponse[];
+  isLoadingConversations?: boolean;
+  isLoadingResponses?: boolean;
+  isGenerating?: boolean;
+  conversationErrorMessage?: string;
+  responseErrorMessage?: string;
+  generationErrorMessage?: string;
+  onSelectConversation: (conversationId?: number) => void;
+  onGenerateSummary: (datasetVersionId: number) => Promise<void>;
+  onGenerateInsights: (datasetVersionId: number) => Promise<void>;
+  onGenerateRecommendations: (datasetVersionId: number) => Promise<void>;
+  onAskQuestion: (question: string) => Promise<void>;
+}
+
+export const DatasetAiAssistantWorkspace = ({
+  datasetVersionId,
+  activeConversationId,
+  conversations,
+  responses,
+  isLoadingConversations = false,
+  isLoadingResponses = false,
+  isGenerating = false,
+  conversationErrorMessage,
+  responseErrorMessage,
+  generationErrorMessage,
+  onSelectConversation,
+  onGenerateSummary,
+  onGenerateInsights,
+  onGenerateRecommendations,
+  onAskQuestion,
+}: DatasetAiAssistantWorkspaceProps) => {
+  const { styles } = useStyles();
+
+  return (
+    <div className={styles.layout}>
+      <div className={styles.sideColumn}>
+        <DatasetAiConversationListCard
+          conversations={conversations}
+          activeConversationId={activeConversationId}
+          isLoading={isLoadingConversations}
+          isError={Boolean(conversationErrorMessage)}
+          errorMessage={conversationErrorMessage}
+          onSelectConversation={onSelectConversation}
+        />
+      </div>
+
+      <div className={styles.mainColumn}>
+        {generationErrorMessage ? (
+          <Alert
+            type="error"
+            showIcon
+            message="Unable to generate the AI response"
+            description={generationErrorMessage}
+          />
+        ) : null}
+
+        <DatasetAiQuickActionsCard
+          datasetVersionId={datasetVersionId}
+          isLoading={isGenerating}
+          onGenerateSummary={onGenerateSummary}
+          onGenerateInsights={onGenerateInsights}
+          onGenerateRecommendations={onGenerateRecommendations}
+        />
+        <DatasetAiPromptComposer
+          datasetVersionId={datasetVersionId}
+          activeConversationId={activeConversationId}
+          isSubmitting={isGenerating}
+          onSubmit={onAskQuestion}
+        />
+        <DatasetAiResponseThreadCard
+          responses={responses}
+          activeConversationId={activeConversationId}
+          isLoading={isLoadingResponses}
+          isError={Boolean(responseErrorMessage)}
+          errorMessage={responseErrorMessage}
+        />
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/datasets/ai/datasetAiAssistantWorkspace/style.ts
+++ b/frontend/src/components/datasets/ai/datasetAiAssistantWorkspace/style.ts
@@ -1,0 +1,27 @@
+"use client";
+
+import { createStyles } from "antd-style";
+
+export const useStyles = createStyles(({ css }) => ({
+  layout: css`
+    display: grid;
+    grid-template-columns: minmax(300px, 0.95fr) minmax(0, 1.35fr);
+    gap: 24px;
+
+    @media (max-width: 1180px) {
+      grid-template-columns: minmax(0, 1fr);
+    }
+  `,
+
+  sideColumn: css`
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+  `,
+
+  mainColumn: css`
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+  `,
+}));

--- a/frontend/src/components/datasets/ai/datasetAiConversationListCard/index.tsx
+++ b/frontend/src/components/datasets/ai/datasetAiConversationListCard/index.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { Alert, Card, Empty, Tag, Typography } from "antd";
+import type { AIConversation } from "@/types/datasets";
+import { formatRelativeTime } from "@/utils/datasets";
+import { useStyles } from "./style";
+
+const { Paragraph, Text, Title } = Typography;
+
+interface DatasetAiConversationListCardProps {
+  conversations: AIConversation[];
+  activeConversationId?: number;
+  isLoading?: boolean;
+  isError?: boolean;
+  errorMessage?: string;
+  onSelectConversation: (conversationId?: number) => void;
+}
+
+export const DatasetAiConversationListCard = ({
+  conversations,
+  activeConversationId,
+  isLoading = false,
+  isError = false,
+  errorMessage,
+  onSelectConversation,
+}: DatasetAiConversationListCardProps) => {
+  const { styles, cx } = useStyles();
+
+  return (
+    <Card loading={isLoading} className={styles.card}>
+      <Title level={4}>Stored conversations</Title>
+
+      {isError ? (
+        <Alert
+          type="error"
+          showIcon
+          message="Unable to load stored conversations"
+          description={errorMessage || "Please try loading the assistant again."}
+        />
+      ) : conversations.length === 0 ? (
+        <Empty
+          image={Empty.PRESENTED_IMAGE_SIMPLE}
+          description="No AI conversations have been created for this dataset version yet."
+        />
+      ) : (
+        <div className={styles.list}>
+          {conversations.map((conversation) => (
+            <button
+              key={conversation.id}
+              type="button"
+              className={cx(
+                styles.item,
+                activeConversationId === conversation.id && styles.activeItem,
+              )}
+              onClick={() => onSelectConversation(conversation.id)}
+            >
+              <div className={styles.itemHeader}>
+                <Text strong>
+                  {conversation.latestUserQuery?.trim() || "Assistant response"}
+                </Text>
+                <Tag>{conversation.responseCount} turns</Tag>
+              </div>
+              <Paragraph className={styles.preview}>
+                {conversation.latestResponsePreview ||
+                  "Open this thread to view the stored assistant response."}
+              </Paragraph>
+              <Text className={styles.metaText}>
+                Updated {formatRelativeTime(conversation.lastInteractionTime)}
+              </Text>
+            </button>
+          ))}
+        </div>
+      )}
+    </Card>
+  );
+};

--- a/frontend/src/components/datasets/ai/datasetAiConversationListCard/index.tsx
+++ b/frontend/src/components/datasets/ai/datasetAiConversationListCard/index.tsx
@@ -10,6 +10,7 @@ const { Paragraph, Text, Title } = Typography;
 interface DatasetAiConversationListCardProps {
   conversations: AIConversation[];
   activeConversationId?: number;
+  isExperimentScoped?: boolean;
   isLoading?: boolean;
   isError?: boolean;
   errorMessage?: string;
@@ -19,6 +20,7 @@ interface DatasetAiConversationListCardProps {
 export const DatasetAiConversationListCard = ({
   conversations,
   activeConversationId,
+  isExperimentScoped = false,
   isLoading = false,
   isError = false,
   errorMessage,
@@ -40,7 +42,11 @@ export const DatasetAiConversationListCard = ({
       ) : conversations.length === 0 ? (
         <Empty
           image={Empty.PRESENTED_IMAGE_SIMPLE}
-          description="No AI conversations have been created for this dataset version yet."
+          description={
+            isExperimentScoped
+              ? "No AI conversations have been created for this experiment yet."
+              : "No AI conversations have been created for this dataset version yet."
+          }
         />
       ) : (
         <div className={styles.list}>

--- a/frontend/src/components/datasets/ai/datasetAiConversationListCard/style.ts
+++ b/frontend/src/components/datasets/ai/datasetAiConversationListCard/style.ts
@@ -1,0 +1,63 @@
+"use client";
+
+import { createStyles } from "antd-style";
+
+export const useStyles = createStyles(({ token, css }) => ({
+  card: css`
+    &.ant-card {
+      border-radius: 24px;
+      border-color: rgba(40, 58, 92, 0.18);
+      box-shadow: 0 18px 44px rgba(15, 23, 42, 0.08);
+    }
+  `,
+
+  list: css`
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  `,
+
+  item: css`
+    appearance: none;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    width: 100%;
+    padding: 16px;
+    border: 1px solid rgba(40, 58, 92, 0.16);
+    border-radius: 18px;
+    background: rgba(15, 23, 42, 0.03);
+    cursor: pointer;
+    text-align: left;
+    transition:
+      border-color 0.2s ease,
+      background 0.2s ease;
+
+    &:hover {
+      border-color: ${token.colorPrimaryBorder};
+      background: rgba(15, 23, 42, 0.05);
+    }
+  `,
+
+  activeItem: css`
+    border-color: ${token.colorPrimary};
+    background: ${token.colorPrimaryBg};
+  `,
+
+  itemHeader: css`
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+  `,
+
+  preview: css`
+    margin-bottom: 0 !important;
+    color: ${token.colorTextSecondary};
+    white-space: pre-wrap;
+  `,
+
+  metaText: css`
+    color: ${token.colorTextSecondary};
+  `,
+}));

--- a/frontend/src/components/datasets/ai/datasetAiExperimentContextCard/index.tsx
+++ b/frontend/src/components/datasets/ai/datasetAiExperimentContextCard/index.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { Alert, Card, Descriptions, Empty, Tag, Typography } from "antd";
+import type { MlExperiment } from "@/types/ml";
+import { formatDateTime, formatNumber } from "@/utils/datasets";
+import {
+  getMlAlgorithmLabel,
+  getMlExperimentStatusColor,
+  getMlExperimentStatusLabel,
+  getMlTaskTypeLabel,
+} from "@/utils/ml";
+import { useStyles } from "./style";
+
+const { Paragraph, Text, Title } = Typography;
+
+interface DatasetAiExperimentContextCardProps {
+  experiment?: MlExperiment;
+  isLoading?: boolean;
+  isError?: boolean;
+  errorMessage?: string;
+}
+
+export const DatasetAiExperimentContextCard = ({
+  experiment,
+  isLoading = false,
+  isError = false,
+  errorMessage,
+}: DatasetAiExperimentContextCardProps) => {
+  const { styles } = useStyles();
+  const metrics = experiment?.model?.metrics.slice(0, 4) ?? [];
+  const featureImportances =
+    experiment?.model?.featureImportances.slice(0, 4) ?? [];
+
+  return (
+    <Card loading={isLoading} className={styles.card}>
+      <Title level={4}>Experiment context</Title>
+
+      {isError ? (
+        <Alert
+          type="error"
+          showIcon
+          message="Unable to load the selected ML experiment"
+          description={errorMessage || "Please try opening the experiment again."}
+        />
+      ) : !experiment ? (
+        <Empty
+          image={Empty.PRESENTED_IMAGE_SIMPLE}
+          description="Select or launch the assistant from an experiment to ground the thread in ML results."
+        />
+      ) : (
+        <>
+          <Paragraph className={styles.helperText}>
+            The assistant is grounded in this experiment&apos;s configuration,
+            metrics, feature importance, and warnings.
+          </Paragraph>
+
+          <Descriptions
+            size="small"
+            column={1}
+            items={[
+              {
+                key: "workflow",
+                label: "Workflow",
+                children: getMlTaskTypeLabel(experiment.taskType),
+              },
+              {
+                key: "algorithm",
+                label: "Algorithm",
+                children: getMlAlgorithmLabel(experiment.algorithmKey),
+              },
+              {
+                key: "target",
+                label: "Target",
+                children: experiment.targetColumnName || "None",
+              },
+              {
+                key: "status",
+                label: "Status",
+                children: (
+                  <Tag color={getMlExperimentStatusColor(experiment.status)}>
+                    {getMlExperimentStatusLabel(experiment.status)}
+                  </Tag>
+                ),
+              },
+              {
+                key: "completed",
+                label: "Completed",
+                children: experiment.completedAtUtc
+                  ? formatDateTime(experiment.completedAtUtc)
+                  : "Not finished",
+              },
+            ]}
+          />
+
+          <Paragraph>
+            <Text strong>Features</Text>
+          </Paragraph>
+          <div className={styles.tagWrap}>
+            {experiment.features.map((feature) => (
+              <Tag key={feature.datasetColumnId}>
+                {feature.name || `Column ${feature.datasetColumnId}`}
+              </Tag>
+            ))}
+          </div>
+
+          {metrics.length > 0 ? (
+            <>
+              <Paragraph>
+                <Text strong>Top metrics</Text>
+              </Paragraph>
+              <div className={styles.metricList}>
+                {metrics.map((metric) => (
+                  <div key={metric.metricName} className={styles.metricRow}>
+                    <Text>{metric.metricName}</Text>
+                    <Text strong>{formatNumber(metric.metricValue, 4)}</Text>
+                  </div>
+                ))}
+              </div>
+            </>
+          ) : null}
+
+          {featureImportances.length > 0 ? (
+            <>
+              <Paragraph>
+                <Text strong>Top feature importance</Text>
+              </Paragraph>
+              <div className={styles.metricList}>
+                {featureImportances.map((item) => (
+                  <div
+                    key={`${item.datasetColumnId}-${item.rank}`}
+                    className={styles.metricRow}
+                  >
+                    <Text>
+                      {item.columnName || `Column ${item.datasetColumnId}`}
+                    </Text>
+                    <Text strong>{formatNumber(item.importanceScore, 4)}</Text>
+                  </div>
+                ))}
+              </div>
+            </>
+          ) : null}
+        </>
+      )}
+    </Card>
+  );
+};

--- a/frontend/src/components/datasets/ai/datasetAiExperimentContextCard/style.ts
+++ b/frontend/src/components/datasets/ai/datasetAiExperimentContextCard/style.ts
@@ -1,0 +1,35 @@
+"use client";
+
+import { createStyles } from "antd-style";
+
+export const useStyles = createStyles(({ css, token }) => ({
+  card: css`
+    border-radius: 24px;
+    border: 1px solid rgba(118, 145, 191, 0.18);
+    background: rgba(17, 27, 48, 0.82);
+    box-shadow: none;
+  `,
+
+  helperText: css`
+    margin-bottom: 16px !important;
+    color: ${token.colorTextSecondary};
+  `,
+
+  tagWrap: css`
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+  `,
+
+  metricList: css`
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  `,
+
+  metricRow: css`
+    display: flex;
+    justify-content: space-between;
+    gap: 12px;
+  `,
+}));

--- a/frontend/src/components/datasets/ai/datasetAiPromptComposer/index.tsx
+++ b/frontend/src/components/datasets/ai/datasetAiPromptComposer/index.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useState } from "react";
+import { Button, Card, Input, Typography } from "antd";
+import { useStyles } from "./style";
+
+const { Paragraph, Title } = Typography;
+const { TextArea } = Input;
+
+interface DatasetAiPromptComposerProps {
+  datasetVersionId?: number;
+  activeConversationId?: number;
+  isSubmitting?: boolean;
+  onSubmit: (question: string) => Promise<void>;
+}
+
+export const DatasetAiPromptComposer = ({
+  datasetVersionId,
+  activeConversationId,
+  isSubmitting = false,
+  onSubmit,
+}: DatasetAiPromptComposerProps) => {
+  const { styles } = useStyles();
+  const [question, setQuestion] = useState("");
+
+  const handleSubmit = async () => {
+    if (!question.trim()) {
+      return;
+    }
+
+    await onSubmit(question.trim());
+    setQuestion("");
+  };
+
+  return (
+    <Card className={styles.card}>
+      <Title level={4}>Ask about this dataset</Title>
+      <Paragraph className={styles.helperText}>
+        Ask a question in plain language. The assistant will stay grounded in
+        the selected dataset version and continue the current thread when one is
+        open.
+      </Paragraph>
+      <TextArea
+        rows={4}
+        value={question}
+        disabled={!datasetVersionId || isSubmitting}
+        placeholder={
+          activeConversationId
+            ? "Ask a follow-up question about this dataset version"
+            : "Ask a question about this dataset version"
+        }
+        onChange={(event) => setQuestion(event.target.value)}
+      />
+      <div className={styles.actions}>
+        <Button
+          type="primary"
+          loading={isSubmitting}
+          disabled={!datasetVersionId || !question.trim()}
+          onClick={() => void handleSubmit()}
+        >
+          Send question
+        </Button>
+      </div>
+    </Card>
+  );
+};

--- a/frontend/src/components/datasets/ai/datasetAiPromptComposer/style.ts
+++ b/frontend/src/components/datasets/ai/datasetAiPromptComposer/style.ts
@@ -1,0 +1,24 @@
+"use client";
+
+import { createStyles } from "antd-style";
+
+export const useStyles = createStyles(({ css, token }) => ({
+  card: css`
+    &.ant-card {
+      border-radius: 24px;
+      border-color: rgba(40, 58, 92, 0.18);
+      box-shadow: 0 18px 44px rgba(15, 23, 42, 0.08);
+    }
+  `,
+
+  helperText: css`
+    margin-bottom: 16px !important;
+    color: ${token.colorTextSecondary};
+  `,
+
+  actions: css`
+    display: flex;
+    justify-content: flex-end;
+    margin-top: 16px;
+  `,
+}));

--- a/frontend/src/components/datasets/ai/datasetAiQuickActionsCard/index.tsx
+++ b/frontend/src/components/datasets/ai/datasetAiQuickActionsCard/index.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { Button, Card, Typography } from "antd";
+import { useStyles } from "./style";
+
+const { Paragraph, Title } = Typography;
+
+interface DatasetAiQuickActionsCardProps {
+  datasetVersionId?: number;
+  isLoading?: boolean;
+  onGenerateSummary: (datasetVersionId: number) => Promise<void>;
+  onGenerateInsights: (datasetVersionId: number) => Promise<void>;
+  onGenerateRecommendations: (datasetVersionId: number) => Promise<void>;
+}
+
+export const DatasetAiQuickActionsCard = ({
+  datasetVersionId,
+  isLoading = false,
+  onGenerateSummary,
+  onGenerateInsights,
+  onGenerateRecommendations,
+}: DatasetAiQuickActionsCardProps) => {
+  const { styles } = useStyles();
+
+  return (
+    <Card className={styles.card}>
+      <Title level={4}>Quick AI actions</Title>
+      <Paragraph className={styles.helperText}>
+        Start with a guided action if you want the assistant to do the first
+        pass for you.
+      </Paragraph>
+      <div className={styles.actions}>
+        <Button
+          type="primary"
+          loading={isLoading}
+          disabled={!datasetVersionId}
+          onClick={() => datasetVersionId && void onGenerateSummary(datasetVersionId)}
+        >
+          Summarize this dataset
+        </Button>
+        <Button
+          loading={isLoading}
+          disabled={!datasetVersionId}
+          onClick={() => datasetVersionId && void onGenerateInsights(datasetVersionId)}
+        >
+          Explain key issues
+        </Button>
+        <Button
+          loading={isLoading}
+          disabled={!datasetVersionId}
+          onClick={() =>
+            datasetVersionId && void onGenerateRecommendations(datasetVersionId)
+          }
+        >
+          Recommend cleaning steps
+        </Button>
+      </div>
+    </Card>
+  );
+};

--- a/frontend/src/components/datasets/ai/datasetAiQuickActionsCard/index.tsx
+++ b/frontend/src/components/datasets/ai/datasetAiQuickActionsCard/index.tsx
@@ -7,6 +7,7 @@ const { Paragraph, Title } = Typography;
 
 interface DatasetAiQuickActionsCardProps {
   datasetVersionId?: number;
+  isExperimentScoped?: boolean;
   isLoading?: boolean;
   onGenerateSummary: (datasetVersionId: number) => Promise<void>;
   onGenerateInsights: (datasetVersionId: number) => Promise<void>;
@@ -15,6 +16,7 @@ interface DatasetAiQuickActionsCardProps {
 
 export const DatasetAiQuickActionsCard = ({
   datasetVersionId,
+  isExperimentScoped = false,
   isLoading = false,
   onGenerateSummary,
   onGenerateInsights,
@@ -26,8 +28,7 @@ export const DatasetAiQuickActionsCard = ({
     <Card className={styles.card}>
       <Title level={4}>Quick AI actions</Title>
       <Paragraph className={styles.helperText}>
-        Start with a guided action if you want the assistant to do the first
-        pass for you.
+        Start with a guided action if you want the assistant to do the first pass for you.
       </Paragraph>
       <div className={styles.actions}>
         <Button
@@ -36,14 +37,14 @@ export const DatasetAiQuickActionsCard = ({
           disabled={!datasetVersionId}
           onClick={() => datasetVersionId && void onGenerateSummary(datasetVersionId)}
         >
-          Summarize this dataset
+          {isExperimentScoped ? "Summarize this experiment" : "Summarize this dataset"}
         </Button>
         <Button
           loading={isLoading}
           disabled={!datasetVersionId}
           onClick={() => datasetVersionId && void onGenerateInsights(datasetVersionId)}
         >
-          Explain key issues
+          {isExperimentScoped ? "Explain these results" : "Explain key issues"}
         </Button>
         <Button
           loading={isLoading}
@@ -52,7 +53,7 @@ export const DatasetAiQuickActionsCard = ({
             datasetVersionId && void onGenerateRecommendations(datasetVersionId)
           }
         >
-          Recommend cleaning steps
+          {isExperimentScoped ? "Recommend next steps" : "Recommend cleaning steps"}
         </Button>
       </div>
     </Card>

--- a/frontend/src/components/datasets/ai/datasetAiQuickActionsCard/style.ts
+++ b/frontend/src/components/datasets/ai/datasetAiQuickActionsCard/style.ts
@@ -1,0 +1,24 @@
+"use client";
+
+import { createStyles } from "antd-style";
+
+export const useStyles = createStyles(({ token, css }) => ({
+  card: css`
+    &.ant-card {
+      border-radius: 24px;
+      border-color: rgba(40, 58, 92, 0.18);
+      box-shadow: 0 18px 44px rgba(15, 23, 42, 0.08);
+    }
+  `,
+
+  helperText: css`
+    margin-bottom: 20px !important;
+    color: ${token.colorTextSecondary};
+  `,
+
+  actions: css`
+    display: flex;
+    gap: 12px;
+    flex-wrap: wrap;
+  `,
+}));

--- a/frontend/src/components/datasets/ai/datasetAiResponseThreadCard/index.tsx
+++ b/frontend/src/components/datasets/ai/datasetAiResponseThreadCard/index.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { Alert, Card, Empty, Tag, Typography } from "antd";
+import { AIResponseType, type AIResponse } from "@/types/datasets";
+import { formatDateTime } from "@/utils/datasets";
+import { useStyles } from "./style";
+
+const { Paragraph, Text, Title } = Typography;
+
+interface DatasetAiResponseThreadCardProps {
+  responses: AIResponse[];
+  activeConversationId?: number;
+  isLoading?: boolean;
+  isError?: boolean;
+  errorMessage?: string;
+}
+
+const getResponseTypeLabel = (responseType: AIResponseType) => {
+  switch (responseType) {
+    case AIResponseType.Summary:
+      return "Summary";
+    case AIResponseType.Recommendation:
+      return "Recommendation";
+    case AIResponseType.Explanation:
+      return "Explanation";
+    case AIResponseType.Insight:
+      return "Insight";
+    case AIResponseType.QuestionAnswer:
+      return "Q&A";
+    default:
+      return "AI response";
+  }
+};
+
+export const DatasetAiResponseThreadCard = ({
+  responses,
+  activeConversationId,
+  isLoading = false,
+  isError = false,
+  errorMessage,
+}: DatasetAiResponseThreadCardProps) => {
+  const { styles, cx } = useStyles();
+
+  return (
+    <Card loading={isLoading} className={styles.card}>
+      <Title level={4}>Assistant thread</Title>
+
+      {isError ? (
+        <Alert
+          type="error"
+          showIcon
+          message="Unable to load the stored assistant thread"
+          description={errorMessage || "Please try opening the thread again."}
+        />
+      ) : !activeConversationId ? (
+        <Empty
+          image={Empty.PRESENTED_IMAGE_SIMPLE}
+          description="Open an existing conversation or create a new assistant response to start a thread."
+        />
+      ) : responses.length === 0 ? (
+        <Empty
+          image={Empty.PRESENTED_IMAGE_SIMPLE}
+          description="No stored assistant turns are available in this conversation yet."
+        />
+      ) : (
+        <div className={styles.thread}>
+          {responses.map((response) => (
+            <div key={response.id} className={styles.turn}>
+              {response.userQuery?.trim() ? (
+                <div className={cx(styles.bubble, styles.userBubble)}>
+                  <div className={styles.bubbleHeader}>
+                    <Text strong>You</Text>
+                    <Text type="secondary">{formatDateTime(response.creationTime)}</Text>
+                  </div>
+                  <Paragraph className={styles.bubbleText}>
+                    {response.userQuery}
+                  </Paragraph>
+                </div>
+              ) : null}
+
+              <div className={cx(styles.bubble, styles.assistantBubble)}>
+                <div className={styles.bubbleHeader}>
+                  <Text strong>Assistant</Text>
+                  <Tag>{getResponseTypeLabel(response.responseType)}</Tag>
+                </div>
+                <Paragraph className={styles.bubbleText}>
+                  {response.responseContent}
+                </Paragraph>
+                <Paragraph className={styles.helperText}>
+                  Generated {formatDateTime(response.creationTime)}
+                </Paragraph>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </Card>
+  );
+};

--- a/frontend/src/components/datasets/ai/datasetAiResponseThreadCard/style.ts
+++ b/frontend/src/components/datasets/ai/datasetAiResponseThreadCard/style.ts
@@ -1,0 +1,57 @@
+"use client";
+
+import { createStyles } from "antd-style";
+
+export const useStyles = createStyles(({ token, css }) => ({
+  card: css`
+    &.ant-card {
+      border-radius: 24px;
+      border-color: rgba(40, 58, 92, 0.18);
+      box-shadow: 0 18px 44px rgba(15, 23, 42, 0.08);
+    }
+  `,
+
+  thread: css`
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+  `,
+
+  turn: css`
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  `,
+
+  bubble: css`
+    padding: 16px 18px;
+    border-radius: 18px;
+    border: 1px solid rgba(40, 58, 92, 0.14);
+  `,
+
+  userBubble: css`
+    background: rgba(15, 23, 42, 0.04);
+  `,
+
+  assistantBubble: css`
+    background: ${token.colorPrimaryBg};
+  `,
+
+  bubbleHeader: css`
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    margin-bottom: 10px;
+  `,
+
+  bubbleText: css`
+    margin-bottom: 0 !important;
+    white-space: pre-wrap;
+  `,
+
+  helperText: css`
+    margin-bottom: 0 !important;
+    color: ${token.colorTextSecondary};
+  `,
+}));

--- a/frontend/src/components/datasets/details/datasetAutomaticInsightCard/index.tsx
+++ b/frontend/src/components/datasets/details/datasetAutomaticInsightCard/index.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { Alert, Button, Card, Empty, Tag, Typography } from "antd";
+import type { ReactNode } from "react";
+import type { AIResponse } from "@/types/datasets";
+import { formatDateTime } from "@/utils/datasets";
+import { useStyles } from "./style";
+
+const { Paragraph, Title } = Typography;
+
+interface InsightSection {
+  title: string;
+  body: string;
+}
+
+interface DatasetAutomaticInsightCardProps {
+  insight?: AIResponse | null;
+  isLoading?: boolean;
+  isError?: boolean;
+  errorMessage?: string;
+  onRetry?: () => void;
+}
+
+const EXPECTED_SECTION_TITLES = [
+  "Summary",
+  "Key data quality issues",
+  "Notable patterns or anomalies",
+  "Suggested next steps",
+];
+
+const normalizeSectionTitle = (value: string) => value.trim().replace(/:$/, "");
+
+const parseInsightSections = (content?: string | null): InsightSection[] => {
+  if (!content?.trim()) {
+    return [];
+  }
+
+  const normalizedContent = content.replace(/\r\n/g, "\n").trim();
+  const blocks = normalizedContent
+    .split(/\n\s*\n/)
+    .map((block) => block.trim())
+    .filter((block) => block.length > 0);
+
+  const sections = blocks
+    .map((block) => {
+      const [firstLine, ...remainingLines] = block.split("\n");
+      const normalizedTitle = normalizeSectionTitle(firstLine);
+
+      if (!EXPECTED_SECTION_TITLES.includes(normalizedTitle)) {
+        return null;
+      }
+
+      return {
+        title: normalizedTitle,
+        body: remainingLines.join("\n").trim(),
+      };
+    })
+    .filter((section): section is InsightSection => section !== null);
+
+  return sections.length === EXPECTED_SECTION_TITLES.length ? sections : [];
+};
+
+export const DatasetAutomaticInsightCard = ({
+  insight,
+  isLoading = false,
+  isError = false,
+  errorMessage,
+  onRetry,
+}: DatasetAutomaticInsightCardProps) => {
+  const { styles } = useStyles();
+  const sections = parseInsightSections(insight?.responseContent);
+  const extra: ReactNode = insight ? (
+    <Tag color="blue">Generated {formatDateTime(insight.creationTime)}</Tag>
+  ) : null;
+
+  return (
+    <Card loading={isLoading} className={styles.card}>
+      <div className={styles.header}>
+        <div>
+          <Title level={4} className={styles.title}>
+            AI Insight
+          </Title>
+          <Paragraph className={styles.helperText}>
+            Automatic plain-language guidance generated from the latest
+            profiling context for this dataset version.
+          </Paragraph>
+        </div>
+        {extra}
+      </div>
+
+      {isError ? (
+        <div className={styles.body}>
+          <Alert
+            type="error"
+            showIcon
+            message="Unable to load the AI insight"
+            description={
+              errorMessage || "Please try loading the AI insight again."
+            }
+          />
+          {onRetry ? (
+            <Button type="primary" onClick={onRetry}>
+              Retry AI insight
+            </Button>
+          ) : null}
+        </div>
+      ) : !insight ? (
+        <Empty
+          image={Empty.PRESENTED_IMAGE_SIMPLE}
+          description="An automatic AI insight has not been generated for this version yet."
+        />
+      ) : sections.length > 0 ? (
+        <div className={styles.body}>
+          {sections.map((section) => (
+            <div key={section.title} className={styles.section}>
+              <Title level={5} className={styles.sectionTitle}>
+                {section.title}
+              </Title>
+              <Paragraph className={styles.sectionBody}>
+                {section.body || "No additional detail was provided."}
+              </Paragraph>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <Paragraph className={styles.fullText}>{insight.responseContent}</Paragraph>
+      )}
+    </Card>
+  );
+};

--- a/frontend/src/components/datasets/details/datasetAutomaticInsightCard/index.tsx
+++ b/frontend/src/components/datasets/details/datasetAutomaticInsightCard/index.tsx
@@ -19,9 +19,14 @@ interface DatasetAutomaticInsightCardProps {
   isError?: boolean;
   errorMessage?: string;
   onRetry?: () => void;
+  title?: string;
+  description?: string;
+  emptyDescription?: string;
+  retryLabel?: string;
+  expectedSectionTitles?: string[];
 }
 
-const EXPECTED_SECTION_TITLES = [
+const DEFAULT_EXPECTED_SECTION_TITLES = [
   "Summary",
   "Key data quality issues",
   "Notable patterns or anomalies",
@@ -30,7 +35,10 @@ const EXPECTED_SECTION_TITLES = [
 
 const normalizeSectionTitle = (value: string) => value.trim().replace(/:$/, "");
 
-const parseInsightSections = (content?: string | null): InsightSection[] => {
+const parseInsightSections = (
+  content: string | null | undefined,
+  expectedSectionTitles: string[],
+): InsightSection[] => {
   if (!content?.trim()) {
     return [];
   }
@@ -46,7 +54,7 @@ const parseInsightSections = (content?: string | null): InsightSection[] => {
       const [firstLine, ...remainingLines] = block.split("\n");
       const normalizedTitle = normalizeSectionTitle(firstLine);
 
-      if (!EXPECTED_SECTION_TITLES.includes(normalizedTitle)) {
+      if (!expectedSectionTitles.includes(normalizedTitle)) {
         return null;
       }
 
@@ -57,7 +65,7 @@ const parseInsightSections = (content?: string | null): InsightSection[] => {
     })
     .filter((section): section is InsightSection => section !== null);
 
-  return sections.length === EXPECTED_SECTION_TITLES.length ? sections : [];
+  return sections.length === expectedSectionTitles.length ? sections : [];
 };
 
 export const DatasetAutomaticInsightCard = ({
@@ -66,9 +74,17 @@ export const DatasetAutomaticInsightCard = ({
   isError = false,
   errorMessage,
   onRetry,
+  title = "AI Insight",
+  description = "Automatic plain-language guidance generated from the latest profiling context for this dataset version.",
+  emptyDescription = "An automatic AI insight has not been generated for this version yet.",
+  retryLabel = "Retry AI insight",
+  expectedSectionTitles = DEFAULT_EXPECTED_SECTION_TITLES,
 }: DatasetAutomaticInsightCardProps) => {
   const { styles } = useStyles();
-  const sections = parseInsightSections(insight?.responseContent);
+  const sections = parseInsightSections(
+    insight?.responseContent,
+    expectedSectionTitles,
+  );
   const extra: ReactNode = insight ? (
     <Tag color="blue">Generated {formatDateTime(insight.creationTime)}</Tag>
   ) : null;
@@ -78,11 +94,10 @@ export const DatasetAutomaticInsightCard = ({
       <div className={styles.header}>
         <div>
           <Title level={4} className={styles.title}>
-            AI Insight
+            {title}
           </Title>
           <Paragraph className={styles.helperText}>
-            Automatic plain-language guidance generated from the latest
-            profiling context for this dataset version.
+            {description}
           </Paragraph>
         </div>
         {extra}
@@ -100,14 +115,14 @@ export const DatasetAutomaticInsightCard = ({
           />
           {onRetry ? (
             <Button type="primary" onClick={onRetry}>
-              Retry AI insight
+              {retryLabel}
             </Button>
           ) : null}
         </div>
       ) : !insight ? (
         <Empty
           image={Empty.PRESENTED_IMAGE_SIMPLE}
-          description="An automatic AI insight has not been generated for this version yet."
+          description={emptyDescription}
         />
       ) : sections.length > 0 ? (
         <div className={styles.body}>

--- a/frontend/src/components/datasets/details/datasetAutomaticInsightCard/style.ts
+++ b/frontend/src/components/datasets/details/datasetAutomaticInsightCard/style.ts
@@ -1,0 +1,63 @@
+"use client";
+
+import { createStyles } from "antd-style";
+
+export const useStyles = createStyles(({ token, css }) => ({
+  card: css`
+    &.ant-card {
+      border-radius: 24px;
+      border-color: rgba(40, 58, 92, 0.18);
+      background: ${token.colorBgContainer};
+      box-shadow: 0 18px 44px rgba(15, 23, 42, 0.08);
+    }
+  `,
+
+  header: css`
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 16px;
+    margin-bottom: 20px;
+
+    @media (max-width: 820px) {
+      flex-direction: column;
+    }
+  `,
+
+  title: css`
+    margin-bottom: 6px !important;
+  `,
+
+  helperText: css`
+    margin-bottom: 0 !important;
+    color: ${token.colorTextSecondary};
+  `,
+
+  body: css`
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+  `,
+
+  section: css`
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  `,
+
+  sectionTitle: css`
+    margin-bottom: 0 !important;
+  `,
+
+  sectionBody: css`
+    margin-bottom: 0 !important;
+    color: ${token.colorTextSecondary};
+    white-space: pre-wrap;
+  `,
+
+  fullText: css`
+    margin-bottom: 0 !important;
+    color: ${token.colorTextSecondary};
+    white-space: pre-wrap;
+  `,
+}));

--- a/frontend/src/components/datasets/ml/mlExperimentWorkspace/index.tsx
+++ b/frontend/src/components/datasets/ml/mlExperimentWorkspace/index.tsx
@@ -17,10 +17,16 @@ import {
   Typography,
 } from "antd";
 import type { ColumnsType } from "antd/es/table";
+import { DatasetAiAssistantLauncherButton } from "@/components/datasets/ai/datasetAiAssistantLauncherButton";
+import { DatasetAutomaticInsightCard } from "@/components/datasets/details/datasetAutomaticInsightCard";
 import {
   ML_ALGORITHM_OPTIONS,
   ML_EXPERIMENT_POLL_INTERVAL_MS,
 } from "@/constants/ml";
+import {
+  useMlExperimentAutoInsightActions,
+  useMlExperimentAutoInsightState,
+} from "@/providers/mlExperimentAutoInsightProvider";
 import type { DatasetColumn } from "@/types/datasets";
 import {
   MlExperimentStatus,
@@ -50,6 +56,7 @@ const { Paragraph, Text, Title } = Typography;
 const { TextArea } = Input;
 
 interface MlExperimentWorkspaceProps {
+  datasetId?: number;
   datasetVersionId?: number;
   columns: DatasetColumn[];
   hasRawFile: boolean;
@@ -161,7 +168,15 @@ const getExperimentWarnings = (experiment?: MlExperiment) => {
   return Array.from(warningSet);
 };
 
+const ML_AUTO_INSIGHT_SECTION_TITLES = [
+  "Summary",
+  "How the result looks",
+  "Risks or limitations",
+  "Suggested next steps",
+];
+
 export const MlExperimentWorkspace = ({
+  datasetId,
   datasetVersionId,
   columns,
   hasRawFile,
@@ -179,6 +194,10 @@ export const MlExperimentWorkspace = ({
     selectExperiment,
   } = useMlExperimentsActions();
   const {
+    clearLatestAutomaticInsight,
+    getLatestAutomaticInsight,
+  } = useMlExperimentAutoInsightActions();
+  const {
     errorMessage,
     experiments,
     isError,
@@ -187,6 +206,12 @@ export const MlExperimentWorkspace = ({
     isSubmittingExperiment,
     selectedExperimentId,
   } = useMlExperimentsState();
+  const {
+    errorMessage: autoInsightErrorMessage,
+    isError: isAutoInsightError,
+    isLoadingInsight,
+    latestInsight,
+  } = useMlExperimentAutoInsightState();
 
   const currentTaskType = Form.useWatch("taskType", form);
   const currentAlgorithmKey = Form.useWatch("algorithmKey", form);
@@ -257,6 +282,29 @@ export const MlExperimentWorkspace = ({
 
     form.setFieldValue("targetDatasetColumnId", undefined);
   }, [currentTaskType, form]);
+
+  const loadExperimentInsight = useEffectEvent(() => {
+    if (
+      !selectedExperiment ||
+      selectedExperiment.status !== MlExperimentStatus.Completed ||
+      !selectedExperiment.model
+    ) {
+      clearLatestAutomaticInsight();
+      return;
+    }
+
+    void getLatestAutomaticInsight(selectedExperiment.id);
+  });
+
+  useEffect(() => {
+    loadExperimentInsight();
+  }, [
+    clearLatestAutomaticInsight,
+    getLatestAutomaticInsight,
+    selectedExperiment?.id,
+    selectedExperiment?.model,
+    selectedExperiment?.status,
+  ]);
 
   const handleCreateExperiment = async (values: MlExperimentFormValues) => {
     if (!datasetVersionId) {
@@ -625,6 +673,17 @@ export const MlExperimentWorkspace = ({
                   </div>
 
                   <div className={styles.detailActions}>
+                    {datasetId ? (
+                      <DatasetAiAssistantLauncherButton
+                        datasetId={datasetId}
+                        versionId={selectedExperiment.datasetVersionId}
+                        experimentId={selectedExperiment.id}
+                        type="primary"
+                      >
+                        Ask AI about this experiment
+                      </DatasetAiAssistantLauncherButton>
+                    ) : null}
+
                     {selectedExperiment.status === MlExperimentStatus.Pending ? (
                       <Button
                         danger
@@ -680,6 +739,19 @@ export const MlExperimentWorkspace = ({
                       }
                     />
                   ) : null}
+
+                  <DatasetAutomaticInsightCard
+                    insight={latestInsight}
+                    isLoading={isLoadingInsight}
+                    isError={isAutoInsightError}
+                    errorMessage={autoInsightErrorMessage}
+                    onRetry={() => void getLatestAutomaticInsight(selectedExperiment.id)}
+                    title="AI Result Insight"
+                    description="Automatic plain-language guidance generated after this experiment completed."
+                    emptyDescription="An automatic AI insight has not been generated for this experiment yet."
+                    retryLabel="Retry result insight"
+                    expectedSectionTitles={ML_AUTO_INSIGHT_SECTION_TITLES}
+                  />
 
                   {selectedExperiment.model ? (
                     <>

--- a/frontend/src/providers/datasetAiAssistantProvider/actions.tsx
+++ b/frontend/src/providers/datasetAiAssistantProvider/actions.tsx
@@ -1,0 +1,292 @@
+import type { AIConversation, AIResponse } from "@/types/datasets";
+import type { IDatasetAiAssistantStateContext } from "./context";
+
+type DatasetAiAssistantStatePatch = Partial<IDatasetAiAssistantStateContext>;
+
+export enum DatasetAiAssistantActionEnums {
+  getConversationsPending = "DATASET_AI_ASSISTANT_GET_CONVERSATIONS_PENDING",
+  getConversationsSuccess = "DATASET_AI_ASSISTANT_GET_CONVERSATIONS_SUCCESS",
+  getConversationsError = "DATASET_AI_ASSISTANT_GET_CONVERSATIONS_ERROR",
+  getResponsesPending = "DATASET_AI_ASSISTANT_GET_RESPONSES_PENDING",
+  getResponsesSuccess = "DATASET_AI_ASSISTANT_GET_RESPONSES_SUCCESS",
+  getResponsesError = "DATASET_AI_ASSISTANT_GET_RESPONSES_ERROR",
+  generatePending = "DATASET_AI_ASSISTANT_GENERATE_PENDING",
+  generateSuccess = "DATASET_AI_ASSISTANT_GENERATE_SUCCESS",
+  generateError = "DATASET_AI_ASSISTANT_GENERATE_ERROR",
+  setActiveConversation = "DATASET_AI_ASSISTANT_SET_ACTIVE_CONVERSATION",
+  clearConversationState = "DATASET_AI_ASSISTANT_CLEAR",
+}
+
+interface GetConversationsPendingAction {
+  type: DatasetAiAssistantActionEnums.getConversationsPending;
+  payload: DatasetAiAssistantStatePatch;
+}
+
+interface GetConversationsSuccessAction {
+  type: DatasetAiAssistantActionEnums.getConversationsSuccess;
+  payload: DatasetAiAssistantStatePatch;
+}
+
+interface GetConversationsErrorAction {
+  type: DatasetAiAssistantActionEnums.getConversationsError;
+  payload: DatasetAiAssistantStatePatch;
+}
+
+interface GetResponsesPendingAction {
+  type: DatasetAiAssistantActionEnums.getResponsesPending;
+  payload: DatasetAiAssistantStatePatch;
+}
+
+interface GetResponsesSuccessAction {
+  type: DatasetAiAssistantActionEnums.getResponsesSuccess;
+  payload: DatasetAiAssistantStatePatch;
+}
+
+interface GetResponsesErrorAction {
+  type: DatasetAiAssistantActionEnums.getResponsesError;
+  payload: DatasetAiAssistantStatePatch;
+}
+
+interface GeneratePendingAction {
+  type: DatasetAiAssistantActionEnums.generatePending;
+  payload: DatasetAiAssistantStatePatch;
+}
+
+interface GenerateSuccessAction {
+  type: DatasetAiAssistantActionEnums.generateSuccess;
+  payload: DatasetAiAssistantStatePatch;
+}
+
+interface GenerateErrorAction {
+  type: DatasetAiAssistantActionEnums.generateError;
+  payload: DatasetAiAssistantStatePatch;
+}
+
+interface SetActiveConversationAction {
+  type: DatasetAiAssistantActionEnums.setActiveConversation;
+  payload: DatasetAiAssistantStatePatch;
+}
+
+interface ClearConversationStateAction {
+  type: DatasetAiAssistantActionEnums.clearConversationState;
+  payload: DatasetAiAssistantStatePatch;
+}
+
+export type DatasetAiAssistantAction =
+  | GetConversationsPendingAction
+  | GetConversationsSuccessAction
+  | GetConversationsErrorAction
+  | GetResponsesPendingAction
+  | GetResponsesSuccessAction
+  | GetResponsesErrorAction
+  | GeneratePendingAction
+  | GenerateSuccessAction
+  | GenerateErrorAction
+  | SetActiveConversationAction
+  | ClearConversationStateAction;
+
+export const getConversationsPending = ({
+  datasetId,
+  datasetVersionId,
+}: {
+  datasetId: number;
+  datasetVersionId?: number;
+}): GetConversationsPendingAction => ({
+  type: DatasetAiAssistantActionEnums.getConversationsPending,
+  payload: {
+    activeDatasetId: datasetId,
+    activeDatasetVersionId: datasetVersionId,
+    isLoadingConversations: true,
+    isPending: true,
+    isError: false,
+    conversationErrorMessage: undefined,
+  },
+});
+
+export const getConversationsSuccess = ({
+  datasetId,
+  datasetVersionId,
+  conversations,
+  totalCount,
+}: {
+  datasetId: number;
+  datasetVersionId?: number;
+  conversations: AIConversation[];
+  totalCount: number;
+}): GetConversationsSuccessAction => ({
+  type: DatasetAiAssistantActionEnums.getConversationsSuccess,
+  payload: {
+    activeDatasetId: datasetId,
+    activeDatasetVersionId: datasetVersionId,
+    conversations,
+    conversationTotalCount: totalCount,
+    isLoadingConversations: false,
+    isPending: false,
+    isError: false,
+    conversationErrorMessage: undefined,
+  },
+});
+
+export const getConversationsError = ({
+  datasetId,
+  datasetVersionId,
+  errorMessage,
+}: {
+  datasetId: number;
+  datasetVersionId?: number;
+  errorMessage: string;
+}): GetConversationsErrorAction => ({
+  type: DatasetAiAssistantActionEnums.getConversationsError,
+  payload: {
+    activeDatasetId: datasetId,
+    activeDatasetVersionId: datasetVersionId,
+    conversations: [],
+    conversationTotalCount: 0,
+    isLoadingConversations: false,
+    isPending: false,
+    isError: true,
+    conversationErrorMessage: errorMessage,
+  },
+});
+
+export const getResponsesPending = ({
+  conversationId,
+}: {
+  conversationId: number;
+}): GetResponsesPendingAction => ({
+  type: DatasetAiAssistantActionEnums.getResponsesPending,
+  payload: {
+    activeConversationId: conversationId,
+    isLoadingResponses: true,
+    isPending: true,
+    isError: false,
+    responseErrorMessage: undefined,
+  },
+});
+
+export const getResponsesSuccess = ({
+  conversationId,
+  responses,
+  totalCount,
+}: {
+  conversationId: number;
+  responses: AIResponse[];
+  totalCount: number;
+}): GetResponsesSuccessAction => ({
+  type: DatasetAiAssistantActionEnums.getResponsesSuccess,
+  payload: {
+    activeConversationId: conversationId,
+    responses,
+    responseTotalCount: totalCount,
+    isLoadingResponses: false,
+    isPending: false,
+    isError: false,
+    responseErrorMessage: undefined,
+  },
+});
+
+export const getResponsesError = ({
+  conversationId,
+  errorMessage,
+}: {
+  conversationId: number;
+  errorMessage: string;
+}): GetResponsesErrorAction => ({
+  type: DatasetAiAssistantActionEnums.getResponsesError,
+  payload: {
+    activeConversationId: conversationId,
+    responses: [],
+    responseTotalCount: 0,
+    isLoadingResponses: false,
+    isPending: false,
+    isError: true,
+    responseErrorMessage: errorMessage,
+  },
+});
+
+export const generatePending = ({
+  datasetVersionId,
+}: {
+  datasetVersionId: number;
+}): GeneratePendingAction => ({
+  type: DatasetAiAssistantActionEnums.generatePending,
+  payload: {
+    activeDatasetVersionId: datasetVersionId,
+    isGenerating: true,
+    isPending: true,
+    isError: false,
+    generationErrorMessage: undefined,
+  },
+});
+
+export const generateSuccess = ({
+  datasetVersionId,
+  conversationId,
+  response,
+}: {
+  datasetVersionId: number;
+  conversationId: number;
+  response: AIResponse;
+}): GenerateSuccessAction => ({
+  type: DatasetAiAssistantActionEnums.generateSuccess,
+  payload: {
+    activeDatasetVersionId: datasetVersionId,
+    activeConversationId: conversationId,
+    lastGeneratedResponse: response,
+    isGenerating: false,
+    isPending: false,
+    isError: false,
+    generationErrorMessage: undefined,
+  },
+});
+
+export const generateError = ({
+  datasetVersionId,
+  errorMessage,
+}: {
+  datasetVersionId: number;
+  errorMessage: string;
+}): GenerateErrorAction => ({
+  type: DatasetAiAssistantActionEnums.generateError,
+  payload: {
+    activeDatasetVersionId: datasetVersionId,
+    isGenerating: false,
+    isPending: false,
+    isError: true,
+    generationErrorMessage: errorMessage,
+  },
+});
+
+export const setActiveConversation = (
+  conversationId?: number,
+): SetActiveConversationAction => ({
+  type: DatasetAiAssistantActionEnums.setActiveConversation,
+  payload: {
+    activeConversationId: conversationId,
+    responses: [],
+    responseTotalCount: 0,
+    responseErrorMessage: undefined,
+  },
+});
+
+export const clearConversationState = (): ClearConversationStateAction => ({
+  type: DatasetAiAssistantActionEnums.clearConversationState,
+  payload: {
+    activeDatasetId: undefined,
+    activeDatasetVersionId: undefined,
+    activeConversationId: undefined,
+    conversations: [],
+    responses: [],
+    conversationTotalCount: 0,
+    responseTotalCount: 0,
+    lastGeneratedResponse: undefined,
+    isLoadingConversations: false,
+    isLoadingResponses: false,
+    isGenerating: false,
+    isPending: false,
+    isError: false,
+    conversationErrorMessage: undefined,
+    responseErrorMessage: undefined,
+    generationErrorMessage: undefined,
+  },
+});

--- a/frontend/src/providers/datasetAiAssistantProvider/actions.tsx
+++ b/frontend/src/providers/datasetAiAssistantProvider/actions.tsx
@@ -1,9 +1,13 @@
 import type { AIConversation, AIResponse } from "@/types/datasets";
+import type { MlExperiment } from "@/types/ml";
 import type { IDatasetAiAssistantStateContext } from "./context";
 
 type DatasetAiAssistantStatePatch = Partial<IDatasetAiAssistantStateContext>;
 
 export enum DatasetAiAssistantActionEnums {
+  loadExperimentContextPending = "DATASET_AI_ASSISTANT_LOAD_EXPERIMENT_CONTEXT_PENDING",
+  loadExperimentContextSuccess = "DATASET_AI_ASSISTANT_LOAD_EXPERIMENT_CONTEXT_SUCCESS",
+  loadExperimentContextError = "DATASET_AI_ASSISTANT_LOAD_EXPERIMENT_CONTEXT_ERROR",
   getConversationsPending = "DATASET_AI_ASSISTANT_GET_CONVERSATIONS_PENDING",
   getConversationsSuccess = "DATASET_AI_ASSISTANT_GET_CONVERSATIONS_SUCCESS",
   getConversationsError = "DATASET_AI_ASSISTANT_GET_CONVERSATIONS_ERROR",
@@ -19,6 +23,21 @@ export enum DatasetAiAssistantActionEnums {
 
 interface GetConversationsPendingAction {
   type: DatasetAiAssistantActionEnums.getConversationsPending;
+  payload: DatasetAiAssistantStatePatch;
+}
+
+interface LoadExperimentContextPendingAction {
+  type: DatasetAiAssistantActionEnums.loadExperimentContextPending;
+  payload: DatasetAiAssistantStatePatch;
+}
+
+interface LoadExperimentContextSuccessAction {
+  type: DatasetAiAssistantActionEnums.loadExperimentContextSuccess;
+  payload: DatasetAiAssistantStatePatch;
+}
+
+interface LoadExperimentContextErrorAction {
+  type: DatasetAiAssistantActionEnums.loadExperimentContextError;
   payload: DatasetAiAssistantStatePatch;
 }
 
@@ -73,6 +92,9 @@ interface ClearConversationStateAction {
 }
 
 export type DatasetAiAssistantAction =
+  | LoadExperimentContextPendingAction
+  | LoadExperimentContextSuccessAction
+  | LoadExperimentContextErrorAction
   | GetConversationsPendingAction
   | GetConversationsSuccessAction
   | GetConversationsErrorAction
@@ -84,6 +106,56 @@ export type DatasetAiAssistantAction =
   | GenerateErrorAction
   | SetActiveConversationAction
   | ClearConversationStateAction;
+
+export const loadExperimentContextPending = ({
+  experimentId,
+}: {
+  experimentId?: number;
+}): LoadExperimentContextPendingAction => ({
+  type: DatasetAiAssistantActionEnums.loadExperimentContextPending,
+  payload: {
+    activeMlExperimentId: experimentId,
+    activeExperiment: undefined,
+    isLoadingExperimentContext: Boolean(experimentId),
+    isPending: Boolean(experimentId),
+    isError: false,
+    experimentContextErrorMessage: undefined,
+  },
+});
+
+export const loadExperimentContextSuccess = ({
+  experiment,
+}: {
+  experiment?: MlExperiment;
+}): LoadExperimentContextSuccessAction => ({
+  type: DatasetAiAssistantActionEnums.loadExperimentContextSuccess,
+  payload: {
+    activeMlExperimentId: experiment?.id,
+    activeExperiment: experiment,
+    isLoadingExperimentContext: false,
+    isPending: false,
+    isError: false,
+    experimentContextErrorMessage: undefined,
+  },
+});
+
+export const loadExperimentContextError = ({
+  experimentId,
+  errorMessage,
+}: {
+  experimentId?: number;
+  errorMessage: string;
+}): LoadExperimentContextErrorAction => ({
+  type: DatasetAiAssistantActionEnums.loadExperimentContextError,
+  payload: {
+    activeMlExperimentId: experimentId,
+    activeExperiment: undefined,
+    isLoadingExperimentContext: false,
+    isPending: false,
+    isError: true,
+    experimentContextErrorMessage: errorMessage,
+  },
+});
 
 export const getConversationsPending = ({
   datasetId,
@@ -206,12 +278,15 @@ export const getResponsesError = ({
 
 export const generatePending = ({
   datasetVersionId,
+  mlExperimentId,
 }: {
   datasetVersionId: number;
+  mlExperimentId?: number;
 }): GeneratePendingAction => ({
   type: DatasetAiAssistantActionEnums.generatePending,
   payload: {
     activeDatasetVersionId: datasetVersionId,
+    activeMlExperimentId: mlExperimentId,
     isGenerating: true,
     isPending: true,
     isError: false,
@@ -232,6 +307,7 @@ export const generateSuccess = ({
   payload: {
     activeDatasetVersionId: datasetVersionId,
     activeConversationId: conversationId,
+    activeMlExperimentId: response.mlExperimentId ?? undefined,
     lastGeneratedResponse: response,
     isGenerating: false,
     isPending: false,
@@ -242,14 +318,17 @@ export const generateSuccess = ({
 
 export const generateError = ({
   datasetVersionId,
+  mlExperimentId,
   errorMessage,
 }: {
   datasetVersionId: number;
+  mlExperimentId?: number;
   errorMessage: string;
 }): GenerateErrorAction => ({
   type: DatasetAiAssistantActionEnums.generateError,
   payload: {
     activeDatasetVersionId: datasetVersionId,
+    activeMlExperimentId: mlExperimentId,
     isGenerating: false,
     isPending: false,
     isError: true,
@@ -275,16 +354,20 @@ export const clearConversationState = (): ClearConversationStateAction => ({
     activeDatasetId: undefined,
     activeDatasetVersionId: undefined,
     activeConversationId: undefined,
+    activeMlExperimentId: undefined,
+    activeExperiment: undefined,
     conversations: [],
     responses: [],
     conversationTotalCount: 0,
     responseTotalCount: 0,
     lastGeneratedResponse: undefined,
+    isLoadingExperimentContext: false,
     isLoadingConversations: false,
     isLoadingResponses: false,
     isGenerating: false,
     isPending: false,
     isError: false,
+    experimentContextErrorMessage: undefined,
     conversationErrorMessage: undefined,
     responseErrorMessage: undefined,
     generationErrorMessage: undefined,

--- a/frontend/src/providers/datasetAiAssistantProvider/context.tsx
+++ b/frontend/src/providers/datasetAiAssistantProvider/context.tsx
@@ -6,31 +6,42 @@ import type {
   GetDatasetAiConversationsRequest,
   GetDatasetAiResponsesRequest,
 } from "@/types/datasets";
+import type { MlExperiment } from "@/types/ml";
+
+export interface IDatasetAiAssistantAskRequest
+  extends AskDatasetAiQuestionRequest {
+  mlExperimentId?: number;
+}
 
 export interface IDatasetAiAssistantStateContext {
   activeDatasetId?: number;
   activeDatasetVersionId?: number;
   activeConversationId?: number;
+  activeMlExperimentId?: number;
+  activeExperiment?: MlExperiment;
   conversations: AIConversation[];
   responses: AIResponse[];
   conversationTotalCount: number;
   responseTotalCount: number;
   lastGeneratedResponse?: AIResponse;
+  isLoadingExperimentContext: boolean;
   isLoadingConversations: boolean;
   isLoadingResponses: boolean;
   isGenerating: boolean;
   isPending: boolean;
   isError: boolean;
+  experimentContextErrorMessage?: string;
   conversationErrorMessage?: string;
   responseErrorMessage?: string;
   generationErrorMessage?: string;
 }
 
 export interface IDatasetAiAssistantActionContext {
+  loadExperimentContext: (experimentId?: number) => Promise<void>;
   generateSummary: (datasetVersionId: number) => Promise<void>;
   generateInsights: (datasetVersionId: number) => Promise<void>;
   generateCleaningRecommendations: (datasetVersionId: number) => Promise<void>;
-  askQuestion: (request: AskDatasetAiQuestionRequest) => Promise<void>;
+  askQuestion: (request: IDatasetAiAssistantAskRequest) => Promise<void>;
   getConversations: (request: GetDatasetAiConversationsRequest) => Promise<void>;
   getResponses: (request: GetDatasetAiResponsesRequest) => Promise<void>;
   setActiveConversation: (conversationId?: number) => void;
@@ -42,6 +53,7 @@ export const INITIAL_STATE: IDatasetAiAssistantStateContext = {
   responses: [],
   conversationTotalCount: 0,
   responseTotalCount: 0,
+  isLoadingExperimentContext: false,
   isLoadingConversations: false,
   isLoadingResponses: false,
   isGenerating: false,

--- a/frontend/src/providers/datasetAiAssistantProvider/context.tsx
+++ b/frontend/src/providers/datasetAiAssistantProvider/context.tsx
@@ -1,0 +1,56 @@
+import { createContext } from "react";
+import type {
+  AIConversation,
+  AIResponse,
+  AskDatasetAiQuestionRequest,
+  GetDatasetAiConversationsRequest,
+  GetDatasetAiResponsesRequest,
+} from "@/types/datasets";
+
+export interface IDatasetAiAssistantStateContext {
+  activeDatasetId?: number;
+  activeDatasetVersionId?: number;
+  activeConversationId?: number;
+  conversations: AIConversation[];
+  responses: AIResponse[];
+  conversationTotalCount: number;
+  responseTotalCount: number;
+  lastGeneratedResponse?: AIResponse;
+  isLoadingConversations: boolean;
+  isLoadingResponses: boolean;
+  isGenerating: boolean;
+  isPending: boolean;
+  isError: boolean;
+  conversationErrorMessage?: string;
+  responseErrorMessage?: string;
+  generationErrorMessage?: string;
+}
+
+export interface IDatasetAiAssistantActionContext {
+  generateSummary: (datasetVersionId: number) => Promise<void>;
+  generateInsights: (datasetVersionId: number) => Promise<void>;
+  generateCleaningRecommendations: (datasetVersionId: number) => Promise<void>;
+  askQuestion: (request: AskDatasetAiQuestionRequest) => Promise<void>;
+  getConversations: (request: GetDatasetAiConversationsRequest) => Promise<void>;
+  getResponses: (request: GetDatasetAiResponsesRequest) => Promise<void>;
+  setActiveConversation: (conversationId?: number) => void;
+  clearConversationState: () => void;
+}
+
+export const INITIAL_STATE: IDatasetAiAssistantStateContext = {
+  conversations: [],
+  responses: [],
+  conversationTotalCount: 0,
+  responseTotalCount: 0,
+  isLoadingConversations: false,
+  isLoadingResponses: false,
+  isGenerating: false,
+  isPending: false,
+  isError: false,
+};
+
+export const DatasetAiAssistantStateContext =
+  createContext<IDatasetAiAssistantStateContext | undefined>(undefined);
+
+export const DatasetAiAssistantActionContext =
+  createContext<IDatasetAiAssistantActionContext | undefined>(undefined);

--- a/frontend/src/providers/datasetAiAssistantProvider/index.tsx
+++ b/frontend/src/providers/datasetAiAssistantProvider/index.tsx
@@ -1,0 +1,233 @@
+"use client";
+
+import { useContext, useReducer } from "react";
+import type { PropsWithChildren } from "react";
+import {
+  askDatasetQuestion as askDatasetQuestionRequest,
+  generateDatasetCleaningRecommendations as generateDatasetCleaningRecommendationsRequest,
+  generateDatasetInsights as generateDatasetInsightsRequest,
+  generateDatasetSummary as generateDatasetSummaryRequest,
+  getDatasetAiConversations as getDatasetAiConversationsRequest,
+  getDatasetAiResponses as getDatasetAiResponsesRequest,
+} from "@/services/datasetService";
+import type {
+  AskDatasetAiQuestionRequest,
+  GenerateDatasetAiResponseResult,
+  GetDatasetAiConversationsRequest,
+  GetDatasetAiResponsesRequest,
+} from "@/types/datasets";
+import { getApiErrorMessage } from "@/utils/apiErrors";
+import {
+  clearConversationState,
+  generateError,
+  generatePending,
+  generateSuccess,
+  getConversationsError,
+  getConversationsPending,
+  getConversationsSuccess,
+  getResponsesError,
+  getResponsesPending,
+  getResponsesSuccess,
+  setActiveConversation as setActiveConversationAction,
+} from "./actions";
+import {
+  DatasetAiAssistantActionContext,
+  DatasetAiAssistantStateContext,
+  INITIAL_STATE,
+} from "./context";
+import { DatasetAiAssistantReducer } from "./reducer";
+
+const DEFAULT_CONVERSATION_PAGE = 1;
+const DEFAULT_CONVERSATION_PAGE_SIZE = 20;
+const DEFAULT_RESPONSE_PAGE = 1;
+const DEFAULT_RESPONSE_PAGE_SIZE = 100;
+
+export const DatasetAiAssistantProvider = ({ children }: PropsWithChildren) => {
+  const [state, dispatch] = useReducer(DatasetAiAssistantReducer, INITIAL_STATE);
+
+  const getConversations = async (request: GetDatasetAiConversationsRequest) => {
+    dispatch(
+      getConversationsPending({
+        datasetId: request.datasetId,
+        datasetVersionId: request.datasetVersionId,
+      }),
+    );
+
+    try {
+      const result = await getDatasetAiConversationsRequest(request);
+      dispatch(
+        getConversationsSuccess({
+          datasetId: request.datasetId,
+          datasetVersionId: request.datasetVersionId,
+          conversations: result.items,
+          totalCount: result.totalCount,
+        }),
+      );
+    } catch (error) {
+      dispatch(
+        getConversationsError({
+          datasetId: request.datasetId,
+          datasetVersionId: request.datasetVersionId,
+          errorMessage: getApiErrorMessage(
+            error,
+            "Unable to load the stored AI conversations right now.",
+          ),
+        }),
+      );
+    }
+  };
+
+  const getResponses = async (request: GetDatasetAiResponsesRequest) => {
+    dispatch(getResponsesPending({ conversationId: request.conversationId }));
+
+    try {
+      const result = await getDatasetAiResponsesRequest(request);
+      dispatch(
+        getResponsesSuccess({
+          conversationId: request.conversationId,
+          responses: result.items,
+          totalCount: result.totalCount,
+        }),
+      );
+    } catch (error) {
+      dispatch(
+        getResponsesError({
+          conversationId: request.conversationId,
+          errorMessage: getApiErrorMessage(
+            error,
+            "Unable to load the stored AI responses right now.",
+          ),
+        }),
+      );
+    }
+  };
+
+  const reloadConversationState = async (
+    datasetVersionId: number,
+    generatedResult: GenerateDatasetAiResponseResult,
+  ) => {
+    if (state.activeDatasetId) {
+      await getConversations({
+        datasetId: state.activeDatasetId,
+        datasetVersionId,
+        page: DEFAULT_CONVERSATION_PAGE,
+        pageSize: DEFAULT_CONVERSATION_PAGE_SIZE,
+      });
+    }
+
+    await getResponses({
+      conversationId: generatedResult.conversationId,
+      page: DEFAULT_RESPONSE_PAGE,
+      pageSize: DEFAULT_RESPONSE_PAGE_SIZE,
+      isChronological: true,
+    });
+  };
+
+  const runGeneration = async (
+    datasetVersionId: number,
+    request: () => Promise<GenerateDatasetAiResponseResult>,
+  ) => {
+    dispatch(generatePending({ datasetVersionId }));
+
+    try {
+      const result = await request();
+      dispatch(
+        generateSuccess({
+          datasetVersionId,
+          conversationId: result.conversationId,
+          response: result.response,
+        }),
+      );
+      await reloadConversationState(datasetVersionId, result);
+    } catch (error) {
+      dispatch(
+        generateError({
+          datasetVersionId,
+          errorMessage: getApiErrorMessage(
+            error,
+            "Unable to generate the dataset AI response right now.",
+          ),
+        }),
+      );
+    }
+  };
+
+  const generateSummary = async (datasetVersionId: number) => {
+    await runGeneration(datasetVersionId, () =>
+      generateDatasetSummaryRequest(datasetVersionId),
+    );
+  };
+
+  const generateInsights = async (datasetVersionId: number) => {
+    await runGeneration(datasetVersionId, () =>
+      generateDatasetInsightsRequest(datasetVersionId),
+    );
+  };
+
+  const generateCleaningRecommendations = async (datasetVersionId: number) => {
+    await runGeneration(datasetVersionId, () =>
+      generateDatasetCleaningRecommendationsRequest(datasetVersionId),
+    );
+  };
+
+  const askQuestion = async (request: AskDatasetAiQuestionRequest) => {
+    await runGeneration(request.datasetVersionId, () =>
+      askDatasetQuestionRequest({
+        datasetVersionId: request.datasetVersionId,
+        question: request.question,
+        conversationId: request.conversationId ?? state.activeConversationId,
+      }),
+    );
+  };
+
+  const setActiveConversation = (conversationId?: number) => {
+    dispatch(setActiveConversationAction(conversationId));
+  };
+
+  const clearAssistantState = () => {
+    dispatch(clearConversationState());
+  };
+
+  return (
+    <DatasetAiAssistantStateContext.Provider value={state}>
+      <DatasetAiAssistantActionContext.Provider
+        value={{
+          generateSummary,
+          generateInsights,
+          generateCleaningRecommendations,
+          askQuestion,
+          getConversations,
+          getResponses,
+          setActiveConversation,
+          clearConversationState: clearAssistantState,
+        }}
+      >
+        {children}
+      </DatasetAiAssistantActionContext.Provider>
+    </DatasetAiAssistantStateContext.Provider>
+  );
+};
+
+export const useDatasetAiAssistantState = () => {
+  const context = useContext(DatasetAiAssistantStateContext);
+
+  if (!context) {
+    throw new Error(
+      "useDatasetAiAssistantState must be used within a DatasetAiAssistantProvider",
+    );
+  }
+
+  return context;
+};
+
+export const useDatasetAiAssistantActions = () => {
+  const context = useContext(DatasetAiAssistantActionContext);
+
+  if (!context) {
+    throw new Error(
+      "useDatasetAiAssistantActions must be used within a DatasetAiAssistantProvider",
+    );
+  }
+
+  return context;
+};

--- a/frontend/src/providers/datasetAiAssistantProvider/index.tsx
+++ b/frontend/src/providers/datasetAiAssistantProvider/index.tsx
@@ -3,15 +3,18 @@
 import { useContext, useReducer } from "react";
 import type { PropsWithChildren } from "react";
 import {
+  askExperimentQuestion as askExperimentQuestionRequest,
   askDatasetQuestion as askDatasetQuestionRequest,
+  generateExperimentRecommendations as generateExperimentRecommendationsRequest,
+  generateExperimentSummary as generateExperimentSummaryRequest,
   generateDatasetCleaningRecommendations as generateDatasetCleaningRecommendationsRequest,
   generateDatasetInsights as generateDatasetInsightsRequest,
   generateDatasetSummary as generateDatasetSummaryRequest,
   getDatasetAiConversations as getDatasetAiConversationsRequest,
   getDatasetAiResponses as getDatasetAiResponsesRequest,
 } from "@/services/datasetService";
+import { getMlExperiment } from "@/services/mlExperimentService";
 import type {
-  AskDatasetAiQuestionRequest,
   GenerateDatasetAiResponseResult,
   GetDatasetAiConversationsRequest,
   GetDatasetAiResponsesRequest,
@@ -28,11 +31,15 @@ import {
   getResponsesError,
   getResponsesPending,
   getResponsesSuccess,
+  loadExperimentContextError,
+  loadExperimentContextPending,
+  loadExperimentContextSuccess,
   setActiveConversation as setActiveConversationAction,
 } from "./actions";
 import {
   DatasetAiAssistantActionContext,
   DatasetAiAssistantStateContext,
+  type IDatasetAiAssistantAskRequest,
   INITIAL_STATE,
 } from "./context";
 import { DatasetAiAssistantReducer } from "./reducer";
@@ -44,6 +51,30 @@ const DEFAULT_RESPONSE_PAGE_SIZE = 100;
 
 export const DatasetAiAssistantProvider = ({ children }: PropsWithChildren) => {
   const [state, dispatch] = useReducer(DatasetAiAssistantReducer, INITIAL_STATE);
+
+  const loadExperimentContext = async (experimentId?: number) => {
+    dispatch(loadExperimentContextPending({ experimentId }));
+
+    if (!experimentId) {
+      dispatch(loadExperimentContextSuccess({ experiment: undefined }));
+      return;
+    }
+
+    try {
+      const experiment = await getMlExperiment(experimentId);
+      dispatch(loadExperimentContextSuccess({ experiment }));
+    } catch (error) {
+      dispatch(
+        loadExperimentContextError({
+          experimentId,
+          errorMessage: getApiErrorMessage(
+            error,
+            "Unable to load the selected ML experiment context right now.",
+          ),
+        }),
+      );
+    }
+  };
 
   const getConversations = async (request: GetDatasetAiConversationsRequest) => {
     dispatch(
@@ -110,6 +141,7 @@ export const DatasetAiAssistantProvider = ({ children }: PropsWithChildren) => {
       await getConversations({
         datasetId: state.activeDatasetId,
         datasetVersionId,
+        mlExperimentId: state.activeMlExperimentId,
         page: DEFAULT_CONVERSATION_PAGE,
         pageSize: DEFAULT_CONVERSATION_PAGE_SIZE,
       });
@@ -125,9 +157,10 @@ export const DatasetAiAssistantProvider = ({ children }: PropsWithChildren) => {
 
   const runGeneration = async (
     datasetVersionId: number,
+    mlExperimentId: number | undefined,
     request: () => Promise<GenerateDatasetAiResponseResult>,
   ) => {
-    dispatch(generatePending({ datasetVersionId }));
+    dispatch(generatePending({ datasetVersionId, mlExperimentId }));
 
     try {
       const result = await request();
@@ -143,6 +176,7 @@ export const DatasetAiAssistantProvider = ({ children }: PropsWithChildren) => {
       dispatch(
         generateError({
           datasetVersionId,
+          mlExperimentId,
           errorMessage: getApiErrorMessage(
             error,
             "Unable to generate the dataset AI response right now.",
@@ -153,30 +187,47 @@ export const DatasetAiAssistantProvider = ({ children }: PropsWithChildren) => {
   };
 
   const generateSummary = async (datasetVersionId: number) => {
-    await runGeneration(datasetVersionId, () =>
-      generateDatasetSummaryRequest(datasetVersionId),
+    await runGeneration(datasetVersionId, state.activeMlExperimentId, () =>
+      state.activeMlExperimentId
+        ? generateExperimentSummaryRequest(state.activeMlExperimentId)
+        : generateDatasetSummaryRequest(datasetVersionId),
     );
   };
 
   const generateInsights = async (datasetVersionId: number) => {
-    await runGeneration(datasetVersionId, () =>
+    await runGeneration(datasetVersionId, undefined, () =>
       generateDatasetInsightsRequest(datasetVersionId),
     );
   };
 
   const generateCleaningRecommendations = async (datasetVersionId: number) => {
-    await runGeneration(datasetVersionId, () =>
-      generateDatasetCleaningRecommendationsRequest(datasetVersionId),
+    await runGeneration(datasetVersionId, state.activeMlExperimentId, () =>
+      state.activeMlExperimentId
+        ? generateExperimentRecommendationsRequest(state.activeMlExperimentId)
+        : generateDatasetCleaningRecommendationsRequest(datasetVersionId),
     );
   };
 
-  const askQuestion = async (request: AskDatasetAiQuestionRequest) => {
-    await runGeneration(request.datasetVersionId, () =>
-      askDatasetQuestionRequest({
-        datasetVersionId: request.datasetVersionId,
-        question: request.question,
-        conversationId: request.conversationId ?? state.activeConversationId,
-      }),
+  const askQuestion = async ({
+    datasetVersionId,
+    question,
+    conversationId,
+    mlExperimentId,
+  }: IDatasetAiAssistantAskRequest) => {
+    const effectiveExperimentId = mlExperimentId ?? state.activeMlExperimentId;
+
+    await runGeneration(datasetVersionId, effectiveExperimentId, () =>
+      effectiveExperimentId
+        ? askExperimentQuestionRequest({
+            mlExperimentId: effectiveExperimentId,
+            question,
+            conversationId: conversationId ?? state.activeConversationId,
+          })
+        : askDatasetQuestionRequest({
+            datasetVersionId,
+            question,
+            conversationId: conversationId ?? state.activeConversationId,
+          }),
     );
   };
 
@@ -192,6 +243,7 @@ export const DatasetAiAssistantProvider = ({ children }: PropsWithChildren) => {
     <DatasetAiAssistantStateContext.Provider value={state}>
       <DatasetAiAssistantActionContext.Provider
         value={{
+          loadExperimentContext,
           generateSummary,
           generateInsights,
           generateCleaningRecommendations,

--- a/frontend/src/providers/datasetAiAssistantProvider/reducer.tsx
+++ b/frontend/src/providers/datasetAiAssistantProvider/reducer.tsx
@@ -1,0 +1,11 @@
+import { INITIAL_STATE } from "./context";
+import type { IDatasetAiAssistantStateContext } from "./context";
+import type { DatasetAiAssistantAction } from "./actions";
+
+export const DatasetAiAssistantReducer = (
+  state: IDatasetAiAssistantStateContext = INITIAL_STATE,
+  action: DatasetAiAssistantAction,
+) => ({
+  ...state,
+  ...action.payload,
+});

--- a/frontend/src/providers/datasetAutoInsightProvider/actions.tsx
+++ b/frontend/src/providers/datasetAutoInsightProvider/actions.tsx
@@ -1,0 +1,102 @@
+import type { AIResponse } from "@/types/datasets";
+import type { IDatasetAutoInsightStateContext } from "./context";
+
+type DatasetAutoInsightStatePatch = Partial<IDatasetAutoInsightStateContext>;
+
+export enum DatasetAutoInsightActionEnums {
+  getInsightPending = "DATASET_AUTO_INSIGHT_PENDING",
+  getInsightSuccess = "DATASET_AUTO_INSIGHT_SUCCESS",
+  getInsightError = "DATASET_AUTO_INSIGHT_ERROR",
+  clearInsight = "DATASET_AUTO_INSIGHT_CLEAR",
+}
+
+interface GetInsightPendingAction {
+  type: DatasetAutoInsightActionEnums.getInsightPending;
+  payload: DatasetAutoInsightStatePatch;
+}
+
+interface GetInsightSuccessAction {
+  type: DatasetAutoInsightActionEnums.getInsightSuccess;
+  payload: DatasetAutoInsightStatePatch;
+}
+
+interface GetInsightErrorAction {
+  type: DatasetAutoInsightActionEnums.getInsightError;
+  payload: DatasetAutoInsightStatePatch;
+}
+
+interface ClearInsightAction {
+  type: DatasetAutoInsightActionEnums.clearInsight;
+  payload: DatasetAutoInsightStatePatch;
+}
+
+export type DatasetAutoInsightAction =
+  | GetInsightPendingAction
+  | GetInsightSuccessAction
+  | GetInsightErrorAction
+  | ClearInsightAction;
+
+export const getInsightPending = (
+  datasetVersionId: number,
+): GetInsightPendingAction => ({
+  type: DatasetAutoInsightActionEnums.getInsightPending,
+  payload: {
+    isLoading: true,
+    isPending: true,
+    isSuccess: false,
+    isError: false,
+    errorMessage: undefined,
+    currentDatasetVersionId: datasetVersionId,
+  },
+});
+
+export const getInsightSuccess = ({
+  datasetVersionId,
+  latestInsight,
+}: {
+  datasetVersionId: number;
+  latestInsight: AIResponse | null;
+}): GetInsightSuccessAction => ({
+  type: DatasetAutoInsightActionEnums.getInsightSuccess,
+  payload: {
+    isLoading: false,
+    isPending: false,
+    isSuccess: true,
+    isError: false,
+    errorMessage: undefined,
+    currentDatasetVersionId: datasetVersionId,
+    latestInsight,
+  },
+});
+
+export const getInsightError = ({
+  datasetVersionId,
+  errorMessage,
+}: {
+  datasetVersionId: number;
+  errorMessage: string;
+}): GetInsightErrorAction => ({
+  type: DatasetAutoInsightActionEnums.getInsightError,
+  payload: {
+    isLoading: false,
+    isPending: false,
+    isSuccess: false,
+    isError: true,
+    errorMessage,
+    currentDatasetVersionId: datasetVersionId,
+    latestInsight: null,
+  },
+});
+
+export const clearInsight = (): ClearInsightAction => ({
+  type: DatasetAutoInsightActionEnums.clearInsight,
+  payload: {
+    isLoading: false,
+    isPending: false,
+    isSuccess: false,
+    isError: false,
+    errorMessage: undefined,
+    currentDatasetVersionId: undefined,
+    latestInsight: null,
+  },
+});

--- a/frontend/src/providers/datasetAutoInsightProvider/context.tsx
+++ b/frontend/src/providers/datasetAutoInsightProvider/context.tsx
@@ -1,0 +1,32 @@
+import { createContext } from "react";
+import type { AIResponse } from "@/types/datasets";
+
+export interface IDatasetAutoInsightStateContext {
+  isLoading: boolean;
+  isPending: boolean;
+  isSuccess: boolean;
+  isError: boolean;
+  errorMessage?: string;
+  currentDatasetVersionId?: number;
+  latestInsight?: AIResponse | null;
+}
+
+export interface IDatasetAutoInsightActionContext {
+  getLatestAutomaticInsight: (datasetVersionId: number) => Promise<void>;
+  refreshLatestAutomaticInsight: () => Promise<void>;
+  clearLatestAutomaticInsight: () => void;
+}
+
+export const INITIAL_STATE: IDatasetAutoInsightStateContext = {
+  isLoading: false,
+  isPending: false,
+  isSuccess: false,
+  isError: false,
+  latestInsight: null,
+};
+
+export const DatasetAutoInsightStateContext =
+  createContext<IDatasetAutoInsightStateContext | undefined>(undefined);
+
+export const DatasetAutoInsightActionContext =
+  createContext<IDatasetAutoInsightActionContext | undefined>(undefined);

--- a/frontend/src/providers/datasetAutoInsightProvider/index.tsx
+++ b/frontend/src/providers/datasetAutoInsightProvider/index.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { useContext, useReducer } from "react";
+import type { PropsWithChildren } from "react";
+import { getLatestAutomaticInsight as getLatestAutomaticInsightRequest } from "@/services/datasetService";
+import { getApiErrorMessage } from "@/utils/apiErrors";
+import {
+  clearInsight,
+  getInsightError,
+  getInsightPending,
+  getInsightSuccess,
+} from "./actions";
+import {
+  DatasetAutoInsightActionContext,
+  DatasetAutoInsightStateContext,
+  INITIAL_STATE,
+} from "./context";
+import { DatasetAutoInsightReducer } from "./reducer";
+
+export const DatasetAutoInsightProvider = ({ children }: PropsWithChildren) => {
+  const [state, dispatch] = useReducer(DatasetAutoInsightReducer, INITIAL_STATE);
+
+  const getLatestAutomaticInsight = async (datasetVersionId: number) => {
+    dispatch(getInsightPending(datasetVersionId));
+
+    try {
+      const latestInsight = await getLatestAutomaticInsightRequest(datasetVersionId);
+      dispatch(getInsightSuccess({ datasetVersionId, latestInsight }));
+    } catch (error) {
+      dispatch(
+        getInsightError({
+          datasetVersionId,
+          errorMessage: getApiErrorMessage(
+            error,
+            "Unable to load the automatic dataset insight right now.",
+          ),
+        }),
+      );
+    }
+  };
+
+  const refreshLatestAutomaticInsight = async () => {
+    if (!state.currentDatasetVersionId) {
+      return;
+    }
+
+    await getLatestAutomaticInsight(state.currentDatasetVersionId);
+  };
+
+  const clearLatestAutomaticInsight = () => {
+    dispatch(clearInsight());
+  };
+
+  return (
+    <DatasetAutoInsightStateContext.Provider value={state}>
+      <DatasetAutoInsightActionContext.Provider
+        value={{
+          getLatestAutomaticInsight,
+          refreshLatestAutomaticInsight,
+          clearLatestAutomaticInsight,
+        }}
+      >
+        {children}
+      </DatasetAutoInsightActionContext.Provider>
+    </DatasetAutoInsightStateContext.Provider>
+  );
+};
+
+export const useDatasetAutoInsightState = () => {
+  const context = useContext(DatasetAutoInsightStateContext);
+
+  if (!context) {
+    throw new Error(
+      "useDatasetAutoInsightState must be used within a DatasetAutoInsightProvider",
+    );
+  }
+
+  return context;
+};
+
+export const useDatasetAutoInsightActions = () => {
+  const context = useContext(DatasetAutoInsightActionContext);
+
+  if (!context) {
+    throw new Error(
+      "useDatasetAutoInsightActions must be used within a DatasetAutoInsightProvider",
+    );
+  }
+
+  return context;
+};

--- a/frontend/src/providers/datasetAutoInsightProvider/reducer.tsx
+++ b/frontend/src/providers/datasetAutoInsightProvider/reducer.tsx
@@ -1,0 +1,11 @@
+import { INITIAL_STATE } from "./context";
+import type { IDatasetAutoInsightStateContext } from "./context";
+import type { DatasetAutoInsightAction } from "./actions";
+
+export const DatasetAutoInsightReducer = (
+  state: IDatasetAutoInsightStateContext = INITIAL_STATE,
+  action: DatasetAutoInsightAction,
+) => ({
+  ...state,
+  ...action.payload,
+});

--- a/frontend/src/providers/mlExperimentAutoInsightProvider/actions.tsx
+++ b/frontend/src/providers/mlExperimentAutoInsightProvider/actions.tsx
@@ -1,0 +1,98 @@
+import type { AIResponse } from "@/types/datasets";
+import type { IMlExperimentAutoInsightStateContext } from "./context";
+
+type MlExperimentAutoInsightStatePatch =
+  Partial<IMlExperimentAutoInsightStateContext>;
+
+export enum MlExperimentAutoInsightActionEnums {
+  getInsightPending = "ML_EXPERIMENT_AUTO_INSIGHT_GET_PENDING",
+  getInsightSuccess = "ML_EXPERIMENT_AUTO_INSIGHT_GET_SUCCESS",
+  getInsightError = "ML_EXPERIMENT_AUTO_INSIGHT_GET_ERROR",
+  clearInsight = "ML_EXPERIMENT_AUTO_INSIGHT_CLEAR",
+}
+
+interface GetInsightPendingAction {
+  type: MlExperimentAutoInsightActionEnums.getInsightPending;
+  payload: MlExperimentAutoInsightStatePatch;
+}
+
+interface GetInsightSuccessAction {
+  type: MlExperimentAutoInsightActionEnums.getInsightSuccess;
+  payload: MlExperimentAutoInsightStatePatch;
+}
+
+interface GetInsightErrorAction {
+  type: MlExperimentAutoInsightActionEnums.getInsightError;
+  payload: MlExperimentAutoInsightStatePatch;
+}
+
+interface ClearInsightAction {
+  type: MlExperimentAutoInsightActionEnums.clearInsight;
+  payload: MlExperimentAutoInsightStatePatch;
+}
+
+export type MlExperimentAutoInsightAction =
+  | GetInsightPendingAction
+  | GetInsightSuccessAction
+  | GetInsightErrorAction
+  | ClearInsightAction;
+
+export const getInsightPending = ({
+  experimentId,
+}: {
+  experimentId?: number;
+}): GetInsightPendingAction => ({
+  type: MlExperimentAutoInsightActionEnums.getInsightPending,
+  payload: {
+    currentExperimentId: experimentId,
+    latestInsight: null,
+    isLoadingInsight: Boolean(experimentId),
+    isError: false,
+    errorMessage: undefined,
+  },
+});
+
+export const getInsightSuccess = ({
+  experimentId,
+  insight,
+}: {
+  experimentId?: number;
+  insight?: AIResponse | null;
+}): GetInsightSuccessAction => ({
+  type: MlExperimentAutoInsightActionEnums.getInsightSuccess,
+  payload: {
+    currentExperimentId: experimentId,
+    latestInsight: insight ?? null,
+    isLoadingInsight: false,
+    isError: false,
+    errorMessage: undefined,
+  },
+});
+
+export const getInsightError = ({
+  experimentId,
+  errorMessage,
+}: {
+  experimentId?: number;
+  errorMessage: string;
+}): GetInsightErrorAction => ({
+  type: MlExperimentAutoInsightActionEnums.getInsightError,
+  payload: {
+    currentExperimentId: experimentId,
+    latestInsight: null,
+    isLoadingInsight: false,
+    isError: true,
+    errorMessage,
+  },
+});
+
+export const clearInsight = (): ClearInsightAction => ({
+  type: MlExperimentAutoInsightActionEnums.clearInsight,
+  payload: {
+    currentExperimentId: undefined,
+    latestInsight: null,
+    isLoadingInsight: false,
+    isError: false,
+    errorMessage: undefined,
+  },
+});

--- a/frontend/src/providers/mlExperimentAutoInsightProvider/context.tsx
+++ b/frontend/src/providers/mlExperimentAutoInsightProvider/context.tsx
@@ -1,0 +1,27 @@
+import { createContext } from "react";
+import type { AIResponse } from "@/types/datasets";
+
+export interface IMlExperimentAutoInsightStateContext {
+  currentExperimentId?: number;
+  latestInsight?: AIResponse | null;
+  isLoadingInsight: boolean;
+  isError: boolean;
+  errorMessage?: string;
+}
+
+export interface IMlExperimentAutoInsightActionContext {
+  getLatestAutomaticInsight: (experimentId?: number) => Promise<void>;
+  clearLatestAutomaticInsight: () => void;
+}
+
+export const INITIAL_STATE: IMlExperimentAutoInsightStateContext = {
+  latestInsight: null,
+  isLoadingInsight: false,
+  isError: false,
+};
+
+export const MlExperimentAutoInsightStateContext =
+  createContext<IMlExperimentAutoInsightStateContext | undefined>(undefined);
+
+export const MlExperimentAutoInsightActionContext =
+  createContext<IMlExperimentAutoInsightActionContext | undefined>(undefined);

--- a/frontend/src/providers/mlExperimentAutoInsightProvider/index.tsx
+++ b/frontend/src/providers/mlExperimentAutoInsightProvider/index.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useContext, useReducer } from "react";
+import type { PropsWithChildren } from "react";
+import { getLatestAutomaticExperimentInsight } from "@/services/datasetService";
+import { getApiErrorMessage } from "@/utils/apiErrors";
+import {
+  clearInsight,
+  getInsightError,
+  getInsightPending,
+  getInsightSuccess,
+} from "./actions";
+import {
+  INITIAL_STATE,
+  MlExperimentAutoInsightActionContext,
+  MlExperimentAutoInsightStateContext,
+} from "./context";
+import { MlExperimentAutoInsightReducer } from "./reducer";
+
+export const MlExperimentAutoInsightProvider = ({
+  children,
+}: PropsWithChildren) => {
+  const [state, dispatch] = useReducer(
+    MlExperimentAutoInsightReducer,
+    INITIAL_STATE,
+  );
+
+  const getLatestAutomaticInsight = async (experimentId?: number) => {
+    dispatch(getInsightPending({ experimentId }));
+
+    if (!experimentId) {
+      dispatch(getInsightSuccess({ experimentId: undefined, insight: null }));
+      return;
+    }
+
+    try {
+      const insight = await getLatestAutomaticExperimentInsight(experimentId);
+      dispatch(getInsightSuccess({ experimentId, insight }));
+    } catch (error) {
+      dispatch(
+        getInsightError({
+          experimentId,
+          errorMessage: getApiErrorMessage(
+            error,
+            "Unable to load the latest automatic ML insight right now.",
+          ),
+        }),
+      );
+    }
+  };
+
+  const clearLatestAutomaticInsight = () => {
+    dispatch(clearInsight());
+  };
+
+  return (
+    <MlExperimentAutoInsightStateContext.Provider value={state}>
+      <MlExperimentAutoInsightActionContext.Provider
+        value={{
+          getLatestAutomaticInsight,
+          clearLatestAutomaticInsight,
+        }}
+      >
+        {children}
+      </MlExperimentAutoInsightActionContext.Provider>
+    </MlExperimentAutoInsightStateContext.Provider>
+  );
+};
+
+export const useMlExperimentAutoInsightState = () => {
+  const context = useContext(MlExperimentAutoInsightStateContext);
+
+  if (!context) {
+    throw new Error(
+      "useMlExperimentAutoInsightState must be used within a MlExperimentAutoInsightProvider",
+    );
+  }
+
+  return context;
+};
+
+export const useMlExperimentAutoInsightActions = () => {
+  const context = useContext(MlExperimentAutoInsightActionContext);
+
+  if (!context) {
+    throw new Error(
+      "useMlExperimentAutoInsightActions must be used within a MlExperimentAutoInsightProvider",
+    );
+  }
+
+  return context;
+};

--- a/frontend/src/providers/mlExperimentAutoInsightProvider/reducer.tsx
+++ b/frontend/src/providers/mlExperimentAutoInsightProvider/reducer.tsx
@@ -1,0 +1,11 @@
+import { INITIAL_STATE } from "./context";
+import type { IMlExperimentAutoInsightStateContext } from "./context";
+import type { MlExperimentAutoInsightAction } from "./actions";
+
+export const MlExperimentAutoInsightReducer = (
+  state: IMlExperimentAutoInsightStateContext = INITIAL_STATE,
+  action: MlExperimentAutoInsightAction,
+) => ({
+  ...state,
+  ...action.payload,
+});

--- a/frontend/src/services/datasetService.ts
+++ b/frontend/src/services/datasetService.ts
@@ -3,6 +3,7 @@ import type {
   AIConversation,
   AIResponse,
   AskDatasetAiQuestionRequest,
+  AskExperimentAiQuestionRequest,
   BarChart,
   DatasetCatalogFilters,
   DatasetColumnInsight,
@@ -68,11 +69,19 @@ const DATASET_AI_GENERATE_INSIGHTS_ENDPOINT =
   "/api/services/app/DatasetAi/GenerateInsights";
 const DATASET_AI_GENERATE_RECOMMENDATIONS_ENDPOINT =
   "/api/services/app/DatasetAi/GenerateCleaningRecommendations";
+const DATASET_AI_GENERATE_EXPERIMENT_SUMMARY_ENDPOINT =
+  "/api/services/app/DatasetAi/GenerateExperimentSummary";
+const DATASET_AI_GENERATE_EXPERIMENT_RECOMMENDATIONS_ENDPOINT =
+  "/api/services/app/DatasetAi/GenerateExperimentRecommendations";
 const DATASET_AI_ASK_ENDPOINT = "/api/services/app/DatasetAi/Ask";
+const DATASET_AI_ASK_EXPERIMENT_ENDPOINT =
+  "/api/services/app/DatasetAi/AskExperiment";
 const DATASET_AI_GET_CONVERSATIONS_ENDPOINT =
   "/api/services/app/DatasetAi/GetConversations";
 const DATASET_AI_GET_RESPONSES_ENDPOINT =
   "/api/services/app/DatasetAi/GetResponses";
+const DATASET_AI_LATEST_AUTOMATIC_EXPERIMENT_INSIGHT_ENDPOINT =
+  "/api/services/app/DatasetAi/GetLatestAutomaticExperimentInsight";
 
 const buildUploadFormData = ({
   name,
@@ -365,6 +374,30 @@ export const generateDatasetCleaningRecommendations = async (
   return response.data.result;
 };
 
+export const generateExperimentSummary = async (
+  mlExperimentId: number,
+): Promise<GenerateDatasetAiResponseResult> => {
+  const response = await axiosInstance.post<
+    AbpApiResponse<GenerateDatasetAiResponseResult>
+  >(DATASET_AI_GENERATE_EXPERIMENT_SUMMARY_ENDPOINT, {
+    id: mlExperimentId,
+  });
+
+  return response.data.result;
+};
+
+export const generateExperimentRecommendations = async (
+  mlExperimentId: number,
+): Promise<GenerateDatasetAiResponseResult> => {
+  const response = await axiosInstance.post<
+    AbpApiResponse<GenerateDatasetAiResponseResult>
+  >(DATASET_AI_GENERATE_EXPERIMENT_RECOMMENDATIONS_ENDPOINT, {
+    id: mlExperimentId,
+  });
+
+  return response.data.result;
+};
+
 export const askDatasetQuestion = async (
   request: AskDatasetAiQuestionRequest,
 ): Promise<GenerateDatasetAiResponseResult> => {
@@ -372,6 +405,20 @@ export const askDatasetQuestion = async (
     AbpApiResponse<GenerateDatasetAiResponseResult>
   >(DATASET_AI_ASK_ENDPOINT, {
     datasetVersionId: request.datasetVersionId,
+    question: request.question,
+    conversationId: request.conversationId,
+  });
+
+  return response.data.result;
+};
+
+export const askExperimentQuestion = async (
+  request: AskExperimentAiQuestionRequest,
+): Promise<GenerateDatasetAiResponseResult> => {
+  const response = await axiosInstance.post<
+    AbpApiResponse<GenerateDatasetAiResponseResult>
+  >(DATASET_AI_ASK_EXPERIMENT_ENDPOINT, {
+    mlExperimentId: request.mlExperimentId,
     question: request.question,
     conversationId: request.conversationId,
   });
@@ -388,12 +435,28 @@ export const getDatasetAiConversations = async (
     params: {
       datasetId: request.datasetId,
       datasetVersionId: request.datasetVersionId,
+      mlExperimentId: request.mlExperimentId,
       skipCount: (request.page - 1) * request.pageSize,
       maxResultCount: request.pageSize,
     },
   });
 
   return response.data.result;
+};
+
+export const getLatestAutomaticExperimentInsight = async (
+  mlExperimentId: number,
+): Promise<AIResponse | null> => {
+  const response = await axiosInstance.get<AbpApiResponse<AIResponse | null>>(
+    DATASET_AI_LATEST_AUTOMATIC_EXPERIMENT_INSIGHT_ENDPOINT,
+    {
+      params: {
+        id: mlExperimentId,
+      },
+    },
+  );
+
+  return response.data.result ?? null;
 };
 
 export const getDatasetAiResponses = async (

--- a/frontend/src/services/datasetService.ts
+++ b/frontend/src/services/datasetService.ts
@@ -1,5 +1,8 @@
 import type { AbpApiResponse, AbpPagedResult } from "@/types/api";
 import type {
+  AIConversation,
+  AIResponse,
+  AskDatasetAiQuestionRequest,
   BarChart,
   DatasetCatalogFilters,
   DatasetColumnInsight,
@@ -25,6 +28,9 @@ import type {
   UploadRawDatasetPayload,
   CorrelationAnalysis,
   DatasetBarChartRequest,
+  GenerateDatasetAiResponseResult,
+  GetDatasetAiConversationsRequest,
+  GetDatasetAiResponsesRequest,
 } from "@/types/datasets";
 import { axiosInstance } from "@/utils/axiosInstance";
 
@@ -54,6 +60,19 @@ const DATASET_EXPLORATION_DISTRIBUTION_ENDPOINT =
   "/api/services/app/DatasetExploration/GetDistribution";
 const DATASET_EXPLORATION_CORRELATION_ENDPOINT =
   "/api/services/app/DatasetExploration/GetCorrelation";
+const DATASET_AI_LATEST_AUTOMATIC_INSIGHT_ENDPOINT =
+  "/api/services/app/DatasetAi/GetLatestAutomaticInsight";
+const DATASET_AI_GENERATE_SUMMARY_ENDPOINT =
+  "/api/services/app/DatasetAi/GenerateSummary";
+const DATASET_AI_GENERATE_INSIGHTS_ENDPOINT =
+  "/api/services/app/DatasetAi/GenerateInsights";
+const DATASET_AI_GENERATE_RECOMMENDATIONS_ENDPOINT =
+  "/api/services/app/DatasetAi/GenerateCleaningRecommendations";
+const DATASET_AI_ASK_ENDPOINT = "/api/services/app/DatasetAi/Ask";
+const DATASET_AI_GET_CONVERSATIONS_ENDPOINT =
+  "/api/services/app/DatasetAi/GetConversations";
+const DATASET_AI_GET_RESPONSES_ENDPOINT =
+  "/api/services/app/DatasetAi/GetResponses";
 
 const buildUploadFormData = ({
   name,
@@ -289,6 +308,105 @@ export const getDatasetCorrelation = async (
     },
     paramsSerializer: {
       indexes: null,
+    },
+  });
+
+  return response.data.result;
+};
+
+export const getLatestAutomaticInsight = async (
+  datasetVersionId: number,
+): Promise<AIResponse | null> => {
+  const response = await axiosInstance.get<AbpApiResponse<AIResponse | null>>(
+    DATASET_AI_LATEST_AUTOMATIC_INSIGHT_ENDPOINT,
+    {
+      params: {
+        id: datasetVersionId,
+      },
+    },
+  );
+
+  return response.data.result ?? null;
+};
+
+export const generateDatasetSummary = async (
+  datasetVersionId: number,
+): Promise<GenerateDatasetAiResponseResult> => {
+  const response = await axiosInstance.post<
+    AbpApiResponse<GenerateDatasetAiResponseResult>
+  >(DATASET_AI_GENERATE_SUMMARY_ENDPOINT, {
+    id: datasetVersionId,
+  });
+
+  return response.data.result;
+};
+
+export const generateDatasetInsights = async (
+  datasetVersionId: number,
+): Promise<GenerateDatasetAiResponseResult> => {
+  const response = await axiosInstance.post<
+    AbpApiResponse<GenerateDatasetAiResponseResult>
+  >(DATASET_AI_GENERATE_INSIGHTS_ENDPOINT, {
+    id: datasetVersionId,
+  });
+
+  return response.data.result;
+};
+
+export const generateDatasetCleaningRecommendations = async (
+  datasetVersionId: number,
+): Promise<GenerateDatasetAiResponseResult> => {
+  const response = await axiosInstance.post<
+    AbpApiResponse<GenerateDatasetAiResponseResult>
+  >(DATASET_AI_GENERATE_RECOMMENDATIONS_ENDPOINT, {
+    id: datasetVersionId,
+  });
+
+  return response.data.result;
+};
+
+export const askDatasetQuestion = async (
+  request: AskDatasetAiQuestionRequest,
+): Promise<GenerateDatasetAiResponseResult> => {
+  const response = await axiosInstance.post<
+    AbpApiResponse<GenerateDatasetAiResponseResult>
+  >(DATASET_AI_ASK_ENDPOINT, {
+    datasetVersionId: request.datasetVersionId,
+    question: request.question,
+    conversationId: request.conversationId,
+  });
+
+  return response.data.result;
+};
+
+export const getDatasetAiConversations = async (
+  request: GetDatasetAiConversationsRequest,
+): Promise<AbpPagedResult<AIConversation>> => {
+  const response = await axiosInstance.get<
+    AbpApiResponse<AbpPagedResult<AIConversation>>
+  >(DATASET_AI_GET_CONVERSATIONS_ENDPOINT, {
+    params: {
+      datasetId: request.datasetId,
+      datasetVersionId: request.datasetVersionId,
+      skipCount: (request.page - 1) * request.pageSize,
+      maxResultCount: request.pageSize,
+    },
+  });
+
+  return response.data.result;
+};
+
+export const getDatasetAiResponses = async (
+  request: GetDatasetAiResponsesRequest,
+): Promise<AbpPagedResult<AIResponse>> => {
+  const response = await axiosInstance.get<
+    AbpApiResponse<AbpPagedResult<AIResponse>>
+  >(DATASET_AI_GET_RESPONSES_ENDPOINT, {
+    params: {
+      conversationId: request.conversationId,
+      skipCount: (request.page - 1) * request.pageSize,
+      maxResultCount: request.pageSize,
+      isChronological: request.isChronological ?? true,
     },
   });
 

--- a/frontend/src/types/datasets.ts
+++ b/frontend/src/types/datasets.ts
@@ -78,6 +78,14 @@ export enum DatasetTransformationDataType {
   String = "string",
 }
 
+export enum AIResponseType {
+  Summary = 1,
+  Recommendation = 2,
+  Explanation = 3,
+  Insight = 4,
+  QuestionAnswer = 5,
+}
+
 export interface Dataset {
   id: number;
   name: string;
@@ -87,6 +95,56 @@ export interface Dataset {
   ownerUserId: number;
   originalFileName: string;
   creationTime: string;
+}
+
+export interface AIResponse {
+  id: number;
+  aiConversationId: number;
+  datasetVersionId: number;
+  userQuery?: string | null;
+  responseContent: string;
+  responseType: AIResponseType;
+  datasetTransformationId?: number | null;
+  metadataJson?: string | null;
+  creationTime: string;
+}
+
+export interface AIConversation {
+  id: number;
+  datasetId: number;
+  ownerUserId: number;
+  lastInteractionTime: string;
+  creationTime: string;
+  responseCount: number;
+  latestDatasetVersionId?: number | null;
+  latestResponseType?: AIResponseType | null;
+  latestUserQuery?: string | null;
+  latestResponsePreview?: string | null;
+}
+
+export interface AskDatasetAiQuestionRequest {
+  datasetVersionId: number;
+  question: string;
+  conversationId?: number;
+}
+
+export interface GenerateDatasetAiResponseResult {
+  conversationId: number;
+  response: AIResponse;
+}
+
+export interface GetDatasetAiConversationsRequest {
+  datasetId: number;
+  datasetVersionId?: number;
+  page: number;
+  pageSize: number;
+}
+
+export interface GetDatasetAiResponsesRequest {
+  conversationId: number;
+  page: number;
+  pageSize: number;
+  isChronological?: boolean;
 }
 
 export interface DatasetColumn {

--- a/frontend/src/types/datasets.ts
+++ b/frontend/src/types/datasets.ts
@@ -105,6 +105,7 @@ export interface AIResponse {
   responseContent: string;
   responseType: AIResponseType;
   datasetTransformationId?: number | null;
+  mlExperimentId?: number | null;
   metadataJson?: string | null;
   creationTime: string;
 }
@@ -118,12 +119,19 @@ export interface AIConversation {
   responseCount: number;
   latestDatasetVersionId?: number | null;
   latestResponseType?: AIResponseType | null;
+  latestMlExperimentId?: number | null;
   latestUserQuery?: string | null;
   latestResponsePreview?: string | null;
 }
 
 export interface AskDatasetAiQuestionRequest {
   datasetVersionId: number;
+  question: string;
+  conversationId?: number;
+}
+
+export interface AskExperimentAiQuestionRequest {
+  mlExperimentId: number;
   question: string;
   conversationId?: number;
 }
@@ -136,6 +144,7 @@ export interface GenerateDatasetAiResponseResult {
 export interface GetDatasetAiConversationsRequest {
   datasetId: number;
   datasetVersionId?: number;
+  mlExperimentId?: number;
   page: number;
   pageSize: number;
 }


### PR DESCRIPTION
## Summary

This PR extends the existing dataset AI slice so it can understand ML experiments, automatically interpret completed ML results, and support experiment-aware AI conversations from the dataset assistant.

Users can now:
- get automatic AI-generated insights after successful ML experiment completion
- launch the dataset assistant with `experimentId` context
- ask AI about a specific experiment’s results
- request experiment summaries and next-step recommendations
- view stored experiment-linked AI responses and conversations

## Backend

### AI + ML context grounding
- Added an internal ML experiment context builder that assembles:
  - selected `MLExperiment`
  - workflow and algorithm details
  - target column
  - selected feature columns
  - model metrics
  - feature importances
  - warnings and performance summary
  - existing dataset-version AI context
- Extended AI prompt building so experiment-aware prompts are grounded in both:
  - dataset-version context
  - ML experiment result context
- Added a dedicated ML-result interpretation prompt mode with plain-language sections:
  - `Summary`
  - `How the result looks`
  - `Risks or limitations`
  - `Suggested next steps`

### Persistence and schema
- Added optional `MLExperimentId` linkage to `AIResponse`
- Added EF configuration and migration for the optional AI-response-to-experiment relationship
- Added navigation properties so experiment-linked AI outputs are queryable and reusable
- Automatic ML insights are persisted as `AIResponseType.Insight`

### AI APIs
- Extended `IDatasetAiAppService` / `DatasetAiAppService` with ML-aware endpoints:
  - `GenerateExperimentSummaryAsync`
  - `GenerateExperimentRecommendationsAsync`
  - `AskExperimentAsync`
  - `GetLatestAutomaticExperimentInsightAsync`
- Extended existing conversation/history reads so they can filter by `mlExperimentId`
- Enforced ownership and tenant validation through the experiment’s dataset version

### Automatic ML insights
- Added a background job that runs after an experiment completes successfully
- Automatic generation is best-effort and asynchronous
- The job skips generation when:
  - the experiment is not completed
  - no model output exists
  - an automatic insight already exists for that experiment
- Automatic ML insight metadata includes:
  - `generationTrigger = experimentCompleted`
  - `mlExperimentId`
  - provider/model metadata

## Frontend

### Dataset assistant
- Extended the dataset assistant route to support:
  - `/datasets/[datasetId]/assistant?versionId=...&experimentId=...`
- Added experiment-aware assistant behavior:
  - loads experiment context when `experimentId` is present
  - scopes conversation history to the selected experiment
  - shows experiment-aware quick actions:
    - summarize this experiment
    - explain these results
    - recommend next steps
- Added an experiment context card in the assistant side rail showing:
  - workflow
  - algorithm
  - target
  - selected features
  - experiment status
  - top metrics / feature importances

### ML workspace
- Added an automatic AI result insight card to the experiment details area
- Added an “Ask AI about this experiment” launcher from ML results into the dataset assistant
- Reused the existing automatic insight presentation pattern for ML-specific result interpretation

### Service and provider wiring
- Extended dataset AI types and service contracts to support:
  - experiment-linked AI responses
  - experiment summary generation
  - experiment recommendations
  - experiment Q&A
  - latest automatic experiment insight
- Extended the dataset AI assistant provider with optional active experiment context
- Added a dedicated ML experiment auto-insight provider for the ML workspace

## User Impact

- Users can now get plain-language interpretation of ML results without manually reading every metric
- Users can ask follow-up questions about a specific experiment directly in the dataset assistant
- AI conversations can stay anchored to one experiment for clearer, safer grounding
- Completed ML runs now feel connected to the broader dataset analysis workflow instead of isolated

## Testing

### Backend
- Verified ML experiment context building
- Verified experiment-aware AI generation and persistence
- Verified automatic ML insight background-job behavior
- Verified experiment-scoped conversation filtering and access control

### Frontend
- Verified experiment-aware assistant routing and context loading
- Verified ML workspace automatic insight rendering
- Verified “Ask AI about this experiment” launch flow
- Verified loading, empty, and error states for both assistant and ML result insight views

### Verification commands
- `dotnet build AstraLab.sln --no-restore -m:1 /p:UseSharedCompilation=false`
- focused backend AI/ML tests
- `npm exec tsc -- --noEmit`
- `npm run lint`
- `npm run build`

### Linked Issues
- Closes #54 
- Closes #55 
- Closes #56 
- Closes #57 
- Closes #58 
- Closes #59 
- Closes #60 
